### PR TITLE
Update Dockerfile to Use Python 3.13-Slim for Latest Stability and Security

### DIFF
--- a/gdbui_server/DockerFile.dev
+++ b/gdbui_server/DockerFile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION

This PR fixes #49 

## **Description**

This PR updates the `DockerFile.dev` to use the latest stable Python image (`python:3.13-slim`) to enhance security, performance, and compatibility with modern libraries.  

### Changes  
- Updated the base image in `DockerFile.dev` to `python:3.13-slim`.  
- Ensured the latest optimizations and security patches are included.  

### Why This Change?  
- The current image is outdated and may contain security vulnerabilities.  
- The new image ensures better compatibility with the latest Python ecosystem.  
- Slim images reduce the overall container size, improving build times and efficiency.  

### Reference  
- [[Docker Hub: Python 3.13-Slim](https://hub.docker.com/layers/library/python/3.13-slim/images/sha256-cdd05847ea468adac731f07eebdd700920cdba58caca6ef25bf8fa8261eb26fc)](https://hub.docker.com/layers/library/python/3.13-slim/images/sha256-cdd05847ea468adac731f07eebdd700920cdba58caca6ef25bf8fa8261eb26fc)  

### Testing  
- Built the updated Docker image and verified successful execution.  