### PR TITLE
fix: correct get_locals to use info locals command

### DIFF
--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -235,17 +235,17 @@ def get_locals():
         start_gdb_session(f'{file}')
 
     try:
-        result = execute_gdb_command("info functions")
+        result = execute_gdb_command("info locals")
         response = {
             'success': True,
             'result': result,
-            'code': "execute_gdb_command('info functions')"
+            'code': "execute_gdb_command('info locals')"
         }
     except Exception as e:
         response = {
             'success': False,
             'error': str(e),
-            'code': "execute_gdb_command('info functions')"
+            'code': "execute_gdb_command('info locals')"
         }
     
     return jsonify(response)


### PR DESCRIPTION
# Fix: /get_locals endpoint uses wrong GDB command

<!-- This PR fixes #NUMBER_OF_THE_ISSUE -->

## Description

This PR fixes a bug in the `/get_locals` endpoint where it was calling `info functions` instead of `info locals`, causing the endpoint to return all functions in the program instead of local variables in the current scope.

### Changes Made

- Changed `execute_gdb_command("info functions")` to `execute_gdb_command("info locals")` in the `get_locals()` function
- Updated error handling code comments to reflect the correct command

### Problem

The `/get_locals` endpoint was incorrectly using the GDB command `info functions`, which returns a list of all functions in the program. This caused the Functions component in the frontend to display function names instead of local variables.

### Solution

Changed the GDB command to `info locals`, which correctly returns local variables in the current execution scope. This ensures the endpoint behaves as expected and the functions component displays the correct information.

### Additional Context

This is a critical bug fix that affects the core functionality of the debugging interface. The Functions component relies on this endpoint to display local variables during debugging sessions.

<!-- 
If you have an issue number, uncomment and add it:
This PR fixes #1
-->