### PR TITLE
Replace deprecated ReactDOM.render with createRoot

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+bun.lock

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,13 +1,15 @@
 // main.jsx
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { DataProvider } from "./context/DataContext";
 import { TerminalContextProvider } from "react-terminal";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.render(
+const root = createRoot(document.getElementById("root"));
+
+root.render(
   <BrowserRouter>
     <DataProvider>
       <TerminalContextProvider>
@@ -16,6 +18,5 @@ ReactDOM.render(
         </React.StrictMode>
       </TerminalContextProvider>
     </DataProvider>
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );


### PR DESCRIPTION
# Replace deprecated ReactDOM.render with createRoot

This PR fixes #86 

## **Description**

- Replaced ReactDOM.render with createRoot to align the app entry point with React 18 and remove the deprecation warning.
- No new dependencies added.
- All frontend tests pass indicating zero regression.

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

- N/A

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->
