### PR TITLE
Fix Breakpoint Add Click When DevTools Closed

### DIFF
--- a/webapp/src/components/MainScreen/MainScreen.jsx
+++ b/webapp/src/components/MainScreen/MainScreen.jsx
@@ -10,8 +10,8 @@ const MainScreen = () => {
       MainScreen
       <div className="mainScreen">
         <Editor
-          height="90vh"
-          className="mainScreen"
+          height="100%"
+          width="100%"
           defaultLanguage="cpp"
           defaultValue="// some comment"
           theme={isDarkMode === "dark" ? "vs-dark" : "vs"}


### PR DESCRIPTION
# **Fix Breakpoint Add Click When DevTools Closed**

This PR fixes #84 

## **Description**

- Prevents the Monaco editor from overlapping the Breakpoint panel by sizing it to its container instead of a fixed viewport height.
- No additional dependencies.

### **Additional context**

- Repro steps from #84 now trigger the click handler with DevTools closed.
