### PR TITLE
fix: migrate ReactDOM.render to createRoot for React 18 compatibility

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,13 +1,14 @@
 // main.jsx
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { DataProvider } from "./context/DataContext";
 import { TerminalContextProvider } from "react-terminal";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <DataProvider>
       <TerminalContextProvider>
@@ -16,6 +17,5 @@ ReactDOM.render(
         </React.StrictMode>
       </TerminalContextProvider>
     </DataProvider>
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );


### PR DESCRIPTION
This pull request fixes #86

## Description
ReactDOM.render is deprecated in React 18 and causes a console warning. 
Migrated to the new createRoot API as recommended by the React team.

## Changes
- Replaced `ReactDOM.render` with `ReactDOM.createRoot` in main.jsx
- Updated import from `react-dom` to `react-dom/client`

## Testing
- App renders correctly at `/`
- No deprecation warnings in console