### PR TITLE
[Security Fix]  Patch Critical RCE via Unsanitized GDB Command Injection in /gdb_command endpoint

### DIFF
--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -12,11 +12,7 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 gdb_controller = None
 program_name = None
 
-# ---------------------------------------------------------------------------
-# Security: Allowlist of GDB commands the UI is permitted to send.
-# Any command NOT starting with one of these prefixes is rejected,
-# preventing Remote Code Execution via GDB's `shell` / `pi` builtins.
-# ---------------------------------------------------------------------------
+# Allowlist of permitted GDB commands
 LIMITED_GDB_COMMANDS = (
     "break ", "break\n",
     "delete ", "delete\n",
@@ -32,7 +28,6 @@ LIMITED_GDB_COMMANDS = (
 )
 
 def is_safe_gdb_command(command: str) -> bool:
-    """Return True only if command starts with a known-safe GDB prefix."""
     if not isinstance(command, str):
         return False
     cmd = command.strip()
@@ -40,10 +35,8 @@ def is_safe_gdb_command(command: str) -> bool:
                for allowed in LIMITED_GDB_COMMANDS)
 
 def sanitize_name(name: str) -> str:
-    """Strip path separators from a user-supplied name to prevent path traversal."""
     if not isinstance(name, str):
         raise ValueError("Name must be a string")
-    # Allow only alphanumeric, dash, underscore, dot
     if not re.match(r'^[\w\-\.]+$', name):
         raise ValueError(f"Invalid name: {name!r}")
     return name
@@ -89,7 +82,6 @@ def gdb_command():
     command = data.get('command')
     file = data.get('name')
 
-    # Security: reject commands not on the safe allowlist
     if not is_safe_gdb_command(command):
         return jsonify({'success': False, 'error': 'Command not permitted.'}), 403
 

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -3,6 +3,7 @@ from pygdbmi.gdbcontroller import GdbController
 from flask_cors import CORS
 import subprocess
 import os
+import re
 
 app = Flask(__name__)
 cors = CORS(app)
@@ -10,6 +11,42 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 
 gdb_controller = None
 program_name = None
+
+# ---------------------------------------------------------------------------
+# Security: Allowlist of GDB commands the UI is permitted to send.
+# Any command NOT starting with one of these prefixes is rejected,
+# preventing Remote Code Execution via GDB's `shell` / `pi` builtins.
+# ---------------------------------------------------------------------------
+LIMITED_GDB_COMMANDS = (
+    "break ", "break\n",
+    "delete ", "delete\n",
+    "info breakpoints",
+    "info registers",
+    "info threads",
+    "info functions",
+    "info locals",
+    "info proc mappings",
+    "watch ",
+    "continue", "next", "step", "finish",
+    "run", "bt",
+)
+
+def is_safe_gdb_command(command: str) -> bool:
+    """Return True only if command starts with a known-safe GDB prefix."""
+    if not isinstance(command, str):
+        return False
+    cmd = command.strip()
+    return any(cmd == allowed.strip() or cmd.startswith(allowed)
+               for allowed in LIMITED_GDB_COMMANDS)
+
+def sanitize_name(name: str) -> str:
+    """Strip path separators from a user-supplied name to prevent path traversal."""
+    if not isinstance(name, str):
+        raise ValueError("Name must be a string")
+    # Allow only alphanumeric, dash, underscore, dot
+    if not re.match(r'^[\w\-\.]+$', name):
+        raise ValueError(f"Invalid name: {name!r}")
+    return name
 
 def execute_gdb_command(command):
     response2 = gdb_controller.write(command)
@@ -51,8 +88,18 @@ def gdb_command():
     data = request.get_json()
     command = data.get('command')
     file = data.get('name')
+
+    # Security: reject commands not on the safe allowlist
+    if not is_safe_gdb_command(command):
+        return jsonify({'success': False, 'error': 'Command not permitted.'}), 403
+
+    try:
+        file = sanitize_name(file)
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
     if program_name != file:
-        start_gdb_session(f'{file}')
+        start_gdb_session(file)
 
     try:
         result = execute_gdb_command(command)
@@ -77,6 +124,12 @@ def compile_code():
     code = data.get('code')
     name = data.get('name')
 
+    # Security: prevent path traversal via name field
+    try:
+        name = sanitize_name(name)
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
     with open(f'{name}.cpp', 'w') as file:
         file.write(code)
 
@@ -98,6 +151,12 @@ def upload_file():
 
     if file.filename == '':
         return jsonify({'success': False, 'error': 'No selected file'}), 400
+
+    # Security: prevent path traversal via name field
+    try:
+        name = sanitize_name(name)
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
 
     file_path = os.path.join('output/', ensure_exe_extension(name))
     file.save(file_path)


### PR DESCRIPTION
# **[Security Fix] Patch Critical RCE via Unsanitized GDB Command Injection**

This PR fixes #97

## **Description**

- Added `is_safe_gdb_command()` - validates all `/gdb_command` requests against a GDB command allowlist, blocking `shell` and `pi` RCE payloads with a `403`.
- Added `sanitize_name()` - regex validation on the `name` field across `/gdb_command`, `/compile`, and `/upload_file` to block path traversal.

### **Additional context**

- No frontend changes needed - all permitted commands (`step`, `next`, `continue`, `break`, `watch`, etc.) work unchanged.
- Malicious payloads like `pi import os; os.system(...)` or `shell whoami` now return `403 Forbidden`.