### PR TITLE
fix: remove deprecated version key from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gdbui_server:
     build:


### PR DESCRIPTION
# **fix: remove deprecated version key from docker-compose.yml**

This PR fixes #81

## **Description**
- Removed the top-level `version: "3"` key from [docker-compose.yml](cci:7://file:///c:/Users/Admin/Desktop/c2si%20GDB/GDB-UI-c2si/docker-compose.yml:0:0-0:0)
- ***

### **Additional context**
- Docker Compose v2+ treats this field as obsolete...
