### PR TITLE
fix: use breakFunction input when set in set_breakpoint API call

### DIFF
--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -19,7 +19,7 @@ const Breakpoint = () => {
     }
     try {
       const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
-        location: breakLine,
+        location: breakFunction || breakLine,
         name: "program",
       });
       console.log(data);

--- a/webapp/src/components/Breakpoint/__tests__/Breakpoint.test.jsx
+++ b/webapp/src/components/Breakpoint/__tests__/Breakpoint.test.jsx
@@ -27,3 +27,12 @@ test("typing in Line input updates the value correctly", () => {
 
   expect(lineInput[0]).toHaveValue("123");
 });
+
+test("typing in Function input updates the value correctly", () => {
+  render(<Breakpoint />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[1], { target: { value: "main" } });
+
+  expect(inputs[1]).toHaveValue("main");
+});


### PR DESCRIPTION
# **fix: use breakFunction input when set in set_breakpoint API call**

This PR fixes #91

## **Description**

- The `breakFunction` state was tracked but never passed to the `/set_breakpoint` API call - the `location` field was always set to `breakLine` regardless of which input was filled
- Updated `handleBreakSave` to send `location: breakFunction || breakLine`, so the function input is used when provided

- ***

### **Additional context**

- Added a test for the Function input field value tracking in `Breakpoint.test.jsx`
- No backend changes required