### PR TITLE
ci: add pip, apt and npm caching to speed up CI workflows

### DIFF
--- a/.github/workflows/run-test-for-server.yml
+++ b/.github/workflows/run-test-for-server.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -21,14 +21,17 @@ jobs:
           git checkout pr
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: gdbui_server/requirements.txt
 
-      - name: Install gdb
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gdb
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: gdb
+          version: 1.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-test-for-webapp.yml
+++ b/.github/workflows/run-test-for-webapp.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "18"
+          cache: "npm"
+          cache-dependency-path: webapp/package-lock.json
 
       - name: Install npm dependencies
         run: |


### PR DESCRIPTION
# **ci: add pip, apt and npm caching to speed up CI workflows**

This PR fixes #76

## **Description**

- Added `cache: "pip"` to `actions/setup-python@v5` in the server workflow to cache pip dependencies across runs
- Added `awalsh128/cache-apt-pkgs-action` to cache the `gdb` apt package, eliminating repeated `sudo apt-get install` on every run
- Added `cache: "npm"` to `actions/setup-node@v4` in the webapp workflow to cache npm dependencies
- Upgraded `actions/checkout` from `v2` to `v4` and `actions/setup-python` from `v2` to `v5` in the server workflow

- ***

### **Additional context**

- No test logic or steps were changed, only caching layers and action versions