### PR TITLE
feat: save compiled code natively on backend (#39)

### DIFF
--- a/gdbui_server/DockerFile.dev
+++ b/gdbui_server/DockerFile.dev
@@ -9,8 +9,8 @@ COPY requirements.txt .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install gdb
-RUN apt-get update && apt-get install -y gdb
+# Install gdb and g++
+RUN apt-get update && apt-get install -y gdb g++
 
 # Copy the rest of the application code
 COPY . .

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -77,14 +77,23 @@ def compile_code():
     code = data.get('code')
     name = data.get('name')
 
-    with open(f'{name}.cpp', 'w') as file:
+    # Security: use sanitize_name if it was added in the previous PR, otherwise standard name.
+    # Since this is a new branch off main (before PR #98 merged), we use raw name or sanitize it manually.
+    if not isinstance(name, str) or '..' in name or '/' in name or '\\' in name:
+        name = "program"
+    
+    os.makedirs('output', exist_ok=True)
+    source_path = os.path.join('output', f'{name}.cpp')
+    binary_path = os.path.join('output', f'{name}.exe')
+
+    with open(source_path, 'w') as file:
         file.write(code)
 
-    result = subprocess.run(['g++', f'{name}.cpp', '-o', f'output/{name}.exe'], capture_output=True, text=True)
+    result = subprocess.run(['g++', source_path, '-o', binary_path], capture_output=True, text=True)
 
     if result.returncode == 0:
         program_name = None
-        return jsonify({'success': True, 'output': 'Compilation successful.'})
+        return jsonify({'success': True, 'output': 'Compilation successful.', 'file_path': binary_path})
     else:
         return jsonify({'success': False, 'output': result.stderr})
 


### PR DESCRIPTION
# **feat: save compiled code natively on backend**

This PR fixes #39

## **Description**

- Updated `DockerFile.dev` to install `g++` alongside `gdb`
- Modified the `/compile` endpoint in `gdbui_server/main.py` to:
  - Save the `.cpp` file in the `output/` directory
  - Compile the code into an `.exe` binary inside the `output/` directory
  - Return the `file_path` of the compiled binary in the JSON response upon success

- ***

### **Additional context**

- Added basic path sanitization for the `name` field to prevent directory traversal writing outside of `output/` (if `#98` is merged first, this resolves automatically).
- Enables the requested debugging feature where backend sources and binaries persist for `gdb` targeting.