### PR TITLE
fix: resolve terminal ignoring consecutive identically-named commands (#106)

### DIFF
--- a/webapp/src/components/DebugHeader/DebugHeader.jsx
+++ b/webapp/src/components/DebugHeader/DebugHeader.jsx
@@ -17,13 +17,12 @@ const DebugHeader = () => {
     refresh,
     setRefresh,
     setTerminalOutput,
-    setCommandPress,
-    commandPress,
+    setCommandCount,
   } = DataState();
 
   const handleRun = (command) => {
     console.log("clicked");
-    setCommandPress(!commandPress);
+    setCommandCount(prev => prev + 1);
     setTerminalOutput(command);
   };
 

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -5,9 +5,9 @@ import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
 const TerminalComp = () => {
-  const { terminalOutput, commandPress } = DataState();
+  const { terminalOutput, commandCount } = DataState();
   const [output, setOutput] = useState("");
-  const terminalRef = useRef("null");
+  const terminalRef = useRef(null);
 
   const handleCommand = async (command, ...args) => {
     const fullCommand = [command, ...args].join(" ");
@@ -35,7 +35,7 @@ const TerminalComp = () => {
       console.log(terminalOutput);
       defaultHandler(terminalOutput);
     }
-  }, [commandPress]);
+  }, [commandCount]);
 
   return (
     <div className="terminal">

--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -17,7 +17,7 @@ export const DataProvider = ({ children }) => {
   const [infoBreakpointData, setInfoBreakpointData] = useState("");
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
-  const [commandPress, setCommandPress] = useState(true);
+  const [commandCount, setCommandCount] = useState(0);
 
   const fetchData = useCallback(async () => {
     if (refresh) {
@@ -56,8 +56,8 @@ export const DataProvider = ({ children }) => {
         dark,
         setDark,
         terminalOutput,
-        setCommandPress,
-        commandPress,
+        setCommandCount,
+        commandCount,
         setTerminalOutput,
       }}
     >


### PR DESCRIPTION
# **fix: resolve terminal ignoring consecutive identically-named commands**

This PR fixes #106

## **Description**

This PR fixes the bug where clicking a debugging control icon (such as "Next" or "Step") twice in a row would result in the second command being silently dropped by the terminal.

- Changed `commandPress` boolean toggle logic to an incrementing `commandCount` state in `DataContext.jsx`. Look at `commandCount` dependencies in UI elements.
- Updated `DebugHeader.jsx` to increment the `commandCount` counter rather than toggling a boolean.
- Updated `TerminalComp.jsx` `useEffect` array to depend on `commandCount`.

- ***

### **Additional context**

Since `commandPress` toggled from `true` to `false` and `terminalOutput` didn't change (e.g. from `next` to `next`), duplicate inputs failed to register a new distinct effect run. Adding an integer counter ensures that React hooks register an update event every time a button is clicked.

Local testing verified the bug is eliminated: subsequent clicks on the exact same command result in new `gdb_command` requests being dispatched to the backend successfully.