### PR TITLE
fix: resolve invalid commands from debug control header icons (#109)

### DIFF
--- a/webapp/src/components/DebugHeader/DebugHeader.jsx
+++ b/webapp/src/components/DebugHeader/DebugHeader.jsx
@@ -36,7 +36,7 @@ const DebugHeader = () => {
               className="icon"
               title="Previous"
               onClick={() => {
-                handleRun("previous");
+                handleRun("reverse-next");
               }}
             />
             <FaArrowRight
@@ -85,9 +85,9 @@ const DebugHeader = () => {
             />
             <BsArrowRightSquareFill
               className="icon"
-              title="Run"
+              title="Step Out"
               onClick={() => {
-                handleRun("step-out");
+                handleRun("finish");
               }}
             />
           </div>


### PR DESCRIPTION
# **fix: resolve invalid commands from debug control header icons**

This PR fixes #109

## **Description**

This PR fixes the bug where clicking the "Previous" or "Step Out" debugging control icons sent invalid strings to the backend GDB wrapper, causing silent failures.

- Updated `FaArrowLeft` (Previous) onClick handler in `DebugHeader.jsx` to send the valid GDB command `"reverse-next"` instead of `"previous"`.
- Updated `BsArrowRightSquareFill` (Step Out) onClick handler in `DebugHeader.jsx` to send the valid GDB command `"finish"` instead of `"step-out"`.

- ***

### **Additional context**

Before this fix, commands were dropped silently since GDB does not recognize "previous" or "step-out". By updating the UI strings to standard GDB commands, the backend processes them natively.