### PR TITLE
fix: use dynamic filename context for backend payload to avoid gdb session resets (#112)

### DIFF
--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -4,14 +4,16 @@ import "./Breakpoint.css";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import axios from "axios";
+import { DataState } from "../../context/DataContext";
 
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
   const [breakFunction, setBreakFunction] = useState("");
+  const { fileName } = DataState();
 
-  const handleBreakSave = async (e) => {
+  const handleSaveBreak = async (e) => {
     e.preventDefault();
-    if (!breakLine && !breakFunction) {
+    if (breakLine === "" && breakFunction === "") {
       toast.error("Enter any of the field", {
         autoClose: 1000,
       });
@@ -19,8 +21,8 @@ const Breakpoint = () => {
     }
     try {
       const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
-        location: breakLine,
-        name: "program",
+        name: fileName,
+        location: breakFunction || breakLine,
       });
       console.log(data);
       toast.success("Added breakpoint", {

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -17,13 +17,13 @@ const data = [
 ];
 
 const Functions = () => {
-  const { refresh, functions, setFunctions } = DataState();
+  const { functions, setFunctions, refresh, fileName } = DataState();
 
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
       const data = await axios.post("http://127.0.0.1:10000/get_locals", {
-        name: "program",
+        name: fileName,
       });
       console.log(data.data.result);
       setFunctions(data.data.result);

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -23,11 +23,11 @@ const data = [
 ];
 
 const BreakPoints = () => {
-  const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
+  const { refresh, setInfoBreakpointData, infoBreakpointData, fileName } = DataState();
 
   const fetchInfoBreakpoints = async () => {
     const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
-      name: "program",
+      name: fileName,
     });
     console.log(data.data["result"]);
     setInfoBreakpointData(data.data["result"]);
@@ -45,7 +45,7 @@ const BreakPoints = () => {
         {infoBreakpointData
           ? infoBreakpointData
           : data?.length > 0
-          ? data.map((obj) => {
+            ? data.map((obj) => {
               return (
                 <div>
                   <div>{obj.offset}</div>
@@ -53,8 +53,8 @@ const BreakPoints = () => {
                 </div>
               );
             })
-          : infoBreakpointData}
-        {}
+            : infoBreakpointData}
+        { }
       </div>
     </div>
   );

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -15,12 +15,12 @@ const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
 ];
 const MemoryMap = () => {
-  const { refresh, memoryMap, setMemoryMap } = DataState();
+  const { memoryMap, setMemoryMap, refresh, fileName } = DataState();
 
   const fetchMemoryMap = async () => {
     console.log("Click form memory map");
     const data = await axios.post("http://127.0.0.1:10000/memory_map", {
-      name: "program",
+      name: fileName,
     });
     console.log(data.data.result);
     setMemoryMap(data.data.result);
@@ -37,10 +37,10 @@ const MemoryMap = () => {
         {memoryMap
           ? memoryMap
           : data?.length > 0
-          ? data.map((obj) => {
+            ? data.map((obj) => {
               return <a>{obj}</a>;
             })
-          : ""}
+            : ""}
       </div>
     </div>
   );

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -4,13 +4,13 @@ import "./Stack.css";
 import axios from "axios";
 
 const Stack = () => {
-  const { refresh, stack, setStack } = DataState();
+  const { stack, setStack, refresh, fileName } = DataState();
 
   const fetStackData = async () => {
     try {
       console.log("click from stack");
       const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
-        name: "program",
+        name: fileName,
       });
       console.log(data.data.result);
       setStack(data.data.result);

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -5,7 +5,7 @@ import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
 const TerminalComp = () => {
-  const { terminalOutput, commandPress } = DataState();
+  const { terminalOutput, commandPress, fileName } = DataState();
   const [output, setOutput] = useState("");
   const terminalRef = useRef("null");
 
@@ -15,7 +15,7 @@ const TerminalComp = () => {
     try {
       const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
         command: fullCommand,
-        name: "program",
+        name: fileName,
       });
       return data["result"];
     } catch (error) {

--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -18,6 +18,8 @@ export const DataProvider = ({ children }) => {
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
   const [commandPress, setCommandPress] = useState(true);
+  const [commandCount, setCommandCount] = useState(0);
+  const [fileName, setFileName] = useState("program");
 
   const fetchData = useCallback(async () => {
     if (refresh) {
@@ -59,6 +61,8 @@ export const DataProvider = ({ children }) => {
         setCommandPress,
         commandPress,
         setTerminalOutput,
+        fileName,
+        setFileName,
       }}
     >
       {children}


### PR DESCRIPTION
# **fix: use dynamic filename context for backend payload to avoid gdb session resets**

This PR fixes #112

## **Description**

The front-end components were collectively hardcoding `name: "program"` in every GDB API request payload. This caused the backend to constantly think the requested file was out of sync if the actual `.exe` didn't have the literal name "program", implicitly wiping the GDB session memory and dropping breakpoints.

- Extracted `"program"` to a `fileName` state inside the `DataContext.jsx`.
- Plumbed `fileName` into the POST payload of `TerminalComp`, `Stack`, `MemoryMap`, `Functions`, `Breakpoint`, and `BreakPoints` components, dynamically allowing the frontend to send whatever filename it is currently interacting with without hardcoding.

- ***

### **Additional context**

This fix does not change application's immediate function (since the variable's default value is still `"program"`). However, once the WebApp begins handling uploads with non-arbitrary executable names, the `setFileName()` dispatch will allow to retain session context instead of repeatedly causing silent GDB crashes and restarts.
