### PR TITLE
refactor: replace hardcoded API base URL with environment variable an…

### DIFF
--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:10000

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000",
+});
+
+export default api;

--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -3,7 +3,7 @@ import "./Breakpoint.css";
 
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import axios from "axios";
+import api from "../../api";
 
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
@@ -18,7 +18,7 @@ const Breakpoint = () => {
       return;
     }
     try {
-      const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
+      const data = await api.post("/set_breakpoint", {
         location: breakLine,
         name: "program",
       });

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Functions.css";
-import axios from "axios";
+import api from "../../api";
 
 const data = [
   "sub.KERNEL32.dll_DeleteCritical_231",
@@ -22,7 +22,7 @@ const Functions = () => {
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+      const data = await api.post("/get_locals", {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
-import axios from "axios";
+import api from "../../../api";
 
 const data = [
   {
@@ -26,7 +26,7 @@ const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
   const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+    const data = await api.post("/info_breakpoints", {
       name: "program",
     });
     console.log(data.data["result"]);

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { DataState } from "./../../../context/DataContext";
 
 import "./MemoryMap.css";
-import axios from "axios";
+import api from "../../../api";
 
 const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
@@ -19,7 +19,7 @@ const MemoryMap = () => {
 
   const fetchMemoryMap = async () => {
     console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+    const data = await api.post("/memory_map", {
       name: "program",
     });
     console.log(data.data.result);

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Stack.css";
-import axios from "axios";
+import api from "../../api";
 
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
@@ -9,7 +9,7 @@ const Stack = () => {
   const fetStackData = async () => {
     try {
       console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+      const data = await api.post("/stack_trace", {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { ReactTerminal } from "react-terminal";
-import axios from "axios";
+import api from "../../api";
 import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
@@ -13,7 +13,7 @@ const TerminalComp = () => {
     const fullCommand = [command, ...args].join(" ");
     console.log("Full Command:", fullCommand);
     try {
-      const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
+      const { data } = await api.post("/gdb_command", {
         command: fullCommand,
         name: "program",
       });


### PR DESCRIPTION
This pull request fixes #83

## Description
Removed hardcoded backend URLs and introduced a shared axios instance using an environment variable.

## Changes
- Added webapp/src/api.js
- Added VITE_API_BASE_URL via .env.example
- Updated all components to use centralized API module
- Removed direct axios + hardcoded URLs

## Testing
- Verified API calls still function locally
- App renders correctly