### PR TITLE
fix: initialize terminalRef with primitive null instead of string (#115)

### DIFF
--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -7,7 +7,7 @@ import { DataState } from "../../context/DataContext";
 const TerminalComp = () => {
   const { terminalOutput, commandPress } = DataState();
   const [output, setOutput] = useState("");
-  const terminalRef = useRef("null");
+  const terminalRef = useRef(null);
 
   const handleCommand = async (command, ...args) => {
     const fullCommand = [command, ...args].join(" ");


### PR DESCRIPTION
# **fix: initialize terminalRef with primitive null instead of string (#115)**

This PR fixes #115.

## **Description**

The `ReactTerminal` hook `terminalRef` in `TerminalComp.jsx` was previously being instantiated with a literal string `"null"`. Since Functional Components specifically refuse strict primitive values passed to a ref prop, it caused React to throw explicit dev-tools warnings (`Warning: Function components cannot be given refs. Attempts to access this ref will fail.`). This also breaks internal autoscrolling and component DOM tracking within the underlying package.

- Replaced `const terminalRef = useRef("null");` with `const terminalRef = useRef(null);`. 

- ***

### **Additional context**

This purely syntactical fix satisfies React's strict DOM-binding rules without changing how the `ReactTerminal` instance resolves the memory allocation.
