### PR TITLE
Feat/connect threads api

### DIFF
--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:10000

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000",
+});
+
+export default api;

--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -3,7 +3,7 @@ import "./Breakpoint.css";
 
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import axios from "axios";
+import api from "../../api";
 
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
@@ -18,7 +18,7 @@ const Breakpoint = () => {
       return;
     }
     try {
-      const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
+      const data = await api.post("/set_breakpoint", {
         location: breakLine,
         name: "program",
       });

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Functions.css";
-import axios from "axios";
+import api from "../../api";
 
 const data = [
   "sub.KERNEL32.dll_DeleteCritical_231",
@@ -22,7 +22,7 @@ const Functions = () => {
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+      const data = await api.post("/get_locals", {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
-import axios from "axios";
+import api from "../../../api";
 
 const data = [
   {
@@ -26,7 +26,7 @@ const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
   const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+    const data = await api.post("/info_breakpoints", {
       name: "program",
     });
     console.log(data.data["result"]);

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { DataState } from "./../../../context/DataContext";
 
 import "./MemoryMap.css";
-import axios from "axios";
+import api from "../../../api";
 
 const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
@@ -19,7 +19,7 @@ const MemoryMap = () => {
 
   const fetchMemoryMap = async () => {
     console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+    const data = await api.post("/memory_map", {
       name: "program",
     });
     console.log(data.data.result);

--- a/webapp/src/components/GdbComponents/Threads/Threads.jsx
+++ b/webapp/src/components/GdbComponents/Threads/Threads.jsx
@@ -9,31 +9,42 @@ const Threads = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const fetchThreadsData = async () => {
+  const fetchThreadsData = async (signal) => {
     setLoading(true);
     setError("");
     try {
       const response = await api.post("/threads", {
-        name: "temp",
+        name: "program",
       });
-      if (response.data.success) {
-        setThreads(response.data.result);
-      } else {
-        setError(response.data.error || "Failed to fetch threads");
+      if (!signal.aborted) {
+        if (response.data.success) {
+          setThreads(response.data.result);
+        } else {
+          setError(response.data.error || "Failed to fetch threads");
+        }
       }
     } catch (err) {
-      console.log(err);
-      setError("Failed to fetch threads");
+      if (!signal.aborted) {
+        console.log(err);
+        setError("Failed to fetch threads");
+      }
     } finally {
-      setLoading(false);
+      if (!signal.aborted) {
+        setLoading(false);
+      }
     }
   };
 
   useEffect(() => {
-    fetchThreadsData();
+    const controller = new AbortController();
+    if (refresh) fetchThreadsData(controller.signal);
+    return () => controller.abort();
   }, [refresh]);
 
-  const hasThreads = threads && !threads.toLowerCase().includes("no threads");
+  const hasThreads =
+    typeof threads === "string" &&
+    threads.trim().length > 0 &&
+    !threads.toLowerCase().includes("no threads");
 
   return (
     <div>

--- a/webapp/src/components/GdbComponents/Threads/Threads.jsx
+++ b/webapp/src/components/GdbComponents/Threads/Threads.jsx
@@ -1,49 +1,42 @@
-import React from "react";
+import React, { useEffect, useState, useContext } from "react";
 import "./Threads.css";
-
-const data = [
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-  {
-    func: "main",
-    file: "temp.cpp:18",
-    addr: "0x10FFF3423WS3234234C",
-    args: "args",
-  },
-];
+import api from "../../../api";
+import { DataContext } from "../../../context/DataContext";
 
 const Threads = () => {
+  const { refresh } = useContext(DataContext);
+  const [threads, setThreads] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchThreadsData = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await api.post("/threads", {
+        name: "temp",
+      });
+      if (response.data.success) {
+        setThreads(response.data.result);
+      } else {
+        setError(response.data.error || "Failed to fetch threads");
+      }
+    } catch (err) {
+      console.log(err);
+      setError("Failed to fetch threads");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchThreadsData();
+  }, [refresh]);
+
+  const hasThreads = threads && !threads.toLowerCase().includes("no threads");
+
   return (
     <div>
-      {/* Threads */}
       <div className="threads">
         <div className="threads-component">
           <div className="threads-component-part1">func</div>
@@ -51,19 +44,14 @@ const Threads = () => {
           <div className="threads-component-part3">addr</div>
           <div className="threads-component-part4">args</div>
         </div>
+
         <div className="threads-lower">
-          {data?.length > 0
-            ? data.map((obj) => {
-                return (
-                  <div className="threads-component">
-                    <div className="threads-component-part1">{obj.func}</div>
-                    <div className="threads-component-part2">{obj.file}</div>
-                    <div className="threads-component-part3">{obj.addr}</div>
-                    <div className="threads-component-part4">{obj.args}</div>
-                  </div>
-                );
-              })
-            : ""}
+          {loading && <div>Loading...</div>}
+          {error && <div>{error}</div>}
+          {!loading && !error && hasThreads && <pre>{threads}</pre>}
+          {!loading && !error && !hasThreads && (
+            <div>No active threads.</div>
+          )}
         </div>
       </div>
     </div>

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Stack.css";
-import axios from "axios";
+import api from "../../api";
 
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
@@ -9,7 +9,7 @@ const Stack = () => {
   const fetStackData = async () => {
     try {
       console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+      const data = await api.post("/stack_trace", {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { ReactTerminal } from "react-terminal";
-import axios from "axios";
+import api from "../../api";
 import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
@@ -13,7 +13,7 @@ const TerminalComp = () => {
     const fullCommand = [command, ...args].join(" ");
     console.log("Full Command:", fullCommand);
     try {
-      const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
+      const { data } = await api.post("/gdb_command", {
         command: fullCommand,
         name: "program",
       });


### PR DESCRIPTION
Replaced the static placeholder data in the Threads component with real data from the /threads backend endpoint.

Previously, the component rendered hardcoded mock thread objects. This PR integrates the centralized api module to fetch actual GDB thread output from the server and render it safely.

Changes made:

- Removed hardcoded thread array

- Added API call to /threads
 
- Added loading and error states
 
- Rendered raw GDB output inside a <pre> block
 
- Added safe handling for empty / "No threads" responses
 
- Ensured no React warnings or console errors