### PR TITLE
fix: remove hardcoded placeholder hex offsets from Stack render (#117)

### DIFF
--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -27,10 +27,6 @@ const Stack = () => {
       Offset
       <div className="stack">
         <div>{stack}</div>
-        <div>0x001780c8 0x001780c8 0x001780c8 0x001780c8</div>
-        <div>0x001780c8 0x001780c8 0x001780c8 0x001780c8</div>
-        <div>0x001780c8 0x001780c8 0x001780c8 0x001780c8</div>
-        <div>0x001780c8 0x001780c8 0x001780c8 0x001780c8</div>
       </div>
     </div>
   );


### PR DESCRIPTION
# **fix: remove hardcoded placeholder hex offsets from Stack render (#117)**

This PR fixes #117.

## **Description**

The `Stack` component previously appended 4 raw rows of hardcoded dummy data (`0x001780c8`) to the end of every stack trace render. This polluted the UI and gave users the false impression that these were actual values fetched from their local GDB debug session memory context.

- Dropped the 4 placeholder `<div>` tags containing the repeated `0x001780c8` strings from `Stack.jsx`.

- ***

### **Additional context**

The component now correctly and exclusively renders the dynamic `stack` trace payload passed back from the python backend, aligning with the expected frontend behavior and leaving no leftover developer mock artifacts. No additional style hacks were necessary.
