### PR TITLE
fix: remove hardcoded placeholder function names from Functions render (#120)

### DIFF
--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -3,18 +3,7 @@ import { DataState } from "./../../context/DataContext";
 import "./Functions.css";
 import axios from "axios";
 
-const data = [
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-  "sub.KERNEL32.dll_DeleteCritical_231",
-];
+
 
 const Functions = () => {
   const { refresh, functions, setFunctions } = DataState();
@@ -44,10 +33,6 @@ const Functions = () => {
       offset
       <div className="functions">
         {functions}
-        {data.map((obj) => {
-          return <a>{obj}</a>;
-        })}
-        {/* <a>sub.KERNEL32.dll_DeleteCritical_231</a> */}
       </div>
     </div>
   );


### PR DESCRIPTION
# **fix: remove hardcoded placeholder function names from Functions render (#120)**

This PR fixes #120.

## **Description**

The `Functions` component previously appended 10 raw rows of hardcoded dummy data (`"sub.KERNEL32.dll_DeleteCritical_231"`) alongside every valid result set. This polluted the UI and gave users the false impression that these were actual values fetched from their local GDB debug session context.

- Dropped the static `data` array containing the repeated `"sub.KERNEL32.dll_DeleteCritical_231"` strings from `Functions.jsx`.
- Removed the mapping iteration in the render block that appended these mocks.

- ***

### **Additional context**

The component now correctly and exclusively renders the dynamic function symbols payload passed back from the python backend via `get_locals`, aligning with expected frontend behavior and leaving no leftover developer mock artifacts. No additional styling was necessary to accommodate the change.
