### PR TITLE
fix: remove hardcoded placeholder developer file paths from BreakPoints

### DIFF
--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -3,25 +3,6 @@ import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
 import axios from "axios";
 
-const data = [
-  {
-    offset: "0x2fffa36f603112ffff34",
-    addr: "/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18",
-  },
-  {
-    offset: "0x2fffa36f603112ffff34",
-    addr: "/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18",
-  },
-  {
-    offset: "0x2fffa36f603112ffff34",
-    addr: "/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18",
-  },
-  {
-    offset: "0x2fffa36f603112ffff34",
-    addr: "/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18",
-  },
-];
-
 const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
@@ -42,19 +23,7 @@ const BreakPoints = () => {
     <div>
       {/* BreakPoints */}
       <div className="breakpoints">
-        {infoBreakpointData
-          ? infoBreakpointData
-          : data?.length > 0
-          ? data.map((obj) => {
-              return (
-                <div>
-                  <div>{obj.offset}</div>
-                  <div>{obj.addr}</div>
-                </div>
-              );
-            })
-          : infoBreakpointData}
-        {}
+        {infoBreakpointData}
       </div>
     </div>
   );


### PR DESCRIPTION
# **fix: remove hardcoded placeholder developer file paths from BreakPoints (#122)**

This Pull Request fixes #122.

## **Description**

The `BreakPoints` React component previously contained a statically defined array of strings named `data`. This array held 4 mock breakpoint objects explicitly containing the filepath `"/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18"`.
Because of a fragile ternary condition in the render output (`{infoBreakpointData ? infoBreakpointData : data?.length > 0 ? data.map(...) : ...}`), this mock array was instantly spilled to every brand new user immediately upon navigating to `/debug` (due to `infoBreakpointData` initially being unpopulated). 

This not only polluted the UI with nonsensical file paths that didn't belong to the user's workspace, but also exposed another developer's local hard drive tree publicly.

- Stripped `const data = ...` array declaration from `BreakPoints.jsx`.
- Completely removed the fallback ternary tree that rendered this array block. 

- ***

### **Additional context**

The component now rigorously renders whatever memory is pushed back via the `infoBreakpointData` state by the `info_breakpoints` GDB event, and correctly evaluates to displaying no breakpoint data locally instead of dumping developer mocks if that payload array is empty. No additional style adjustments were required.
