### PR TITLE
fix: replace hardcoded API base URL with environment variable

### DIFF
--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:10000

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -5,6 +5,8 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import axios from "axios";
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
   const [breakFunction, setBreakFunction] = useState("");
@@ -18,7 +20,7 @@ const Breakpoint = () => {
       return;
     }
     try {
-      const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
+      const data = await axios.post(`${API_BASE_URL}/set_breakpoint`, {
         location: breakLine,
         name: "program",
       });
@@ -32,6 +34,7 @@ const Breakpoint = () => {
       });
     }
   };
+
   return (
     <div className="breakpoint-container">
       <div className="add-breakpoint">Add Breakpoint</div>

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -3,7 +3,9 @@ import { DataState } from "./../../context/DataContext";
 import "./Functions.css";
 import axios from "axios";
 
-const data = [
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
+const hardcodedData = [
   "sub.KERNEL32.dll_DeleteCritical_231",
   "sub.KERNEL32.dll_DeleteCritical_231",
   "sub.KERNEL32.dll_DeleteCritical_231",
@@ -22,7 +24,7 @@ const Functions = () => {
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+      const data = await axios.post(`${API_BASE_URL}/get_locals`, {
         name: "program",
       });
       console.log(data.data.result);
@@ -44,10 +46,9 @@ const Functions = () => {
       offset
       <div className="functions">
         {functions}
-        {data.map((obj) => {
-          return <a>{obj}</a>;
+        {hardcodedData.map((obj, index) => {
+          return <a key={index}>{obj}</a>;
         })}
-        {/* <a>sub.KERNEL32.dll_DeleteCritical_231</a> */}
       </div>
     </div>
   );

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
 import axios from "axios";
 
-const data = [
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
+const hardcodedData = [
   {
     offset: "0x2fffa36f603112ffff34",
     addr: "/Users/shubh/lib/node_modules/@stdlib/math/docs/t.js:18",
@@ -26,35 +28,35 @@ const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
   const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+    const data = await axios.post(`${API_BASE_URL}/info_breakpoints`, {
       name: "program",
     });
     console.log(data.data["result"]);
     setInfoBreakpointData(data.data["result"]);
   };
+
   useEffect(() => {
     if (refresh) {
       console.log("click from breakpoint in GdbComponents");
       fetchInfoBreakpoints();
     }
   }, [refresh]);
+
   return (
     <div>
-      {/* BreakPoints */}
       <div className="breakpoints">
         {infoBreakpointData
           ? infoBreakpointData
-          : data?.length > 0
-          ? data.map((obj) => {
+          : hardcodedData?.length > 0
+          ? hardcodedData.map((obj, index) => {
               return (
-                <div>
+                <div key={index}>
                   <div>{obj.offset}</div>
                   <div>{obj.addr}</div>
                 </div>
               );
             })
           : infoBreakpointData}
-        {}
       </div>
     </div>
   );

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from "react";
 import { DataState } from "./../../../context/DataContext";
-
 import "./MemoryMap.css";
 import axios from "axios";
 
-const data = [
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
+const hardcodedData = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
@@ -14,12 +15,13 @@ const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
 ];
+
 const MemoryMap = () => {
   const { refresh, memoryMap, setMemoryMap } = DataState();
 
   const fetchMemoryMap = async () => {
-    console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+    console.log("Click from memory map");
+    const data = await axios.post(`${API_BASE_URL}/memory_map`, {
       name: "program",
     });
     console.log(data.data.result);
@@ -32,13 +34,12 @@ const MemoryMap = () => {
 
   return (
     <div>
-      {/* MemoryMap */}
       <div className="memoryMap">
         {memoryMap
           ? memoryMap
-          : data?.length > 0
-          ? data.map((obj) => {
-              return <a>{obj}</a>;
+          : hardcodedData?.length > 0
+          ? hardcodedData.map((obj, index) => {
+              return <a key={index}>{obj}</a>;
             })
           : ""}
       </div>

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -3,13 +3,15 @@ import { DataState } from "./../../context/DataContext";
 import "./Stack.css";
 import axios from "axios";
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
 
   const fetStackData = async () => {
     try {
       console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+      const data = await axios.post(`${API_BASE_URL}/stack_trace`, {
         name: "program",
       });
       console.log(data.data.result);
@@ -18,9 +20,11 @@ const Stack = () => {
       console.log(error);
     }
   };
+
   useEffect(() => {
     if (refresh) fetStackData();
   }, [refresh]);
+
   return (
     <div className="stack-parent">
       <div className="stack-heading">Stack</div>

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -4,16 +4,18 @@ import axios from "axios";
 import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
+
 const TerminalComp = () => {
   const { terminalOutput, commandPress } = DataState();
   const [output, setOutput] = useState("");
-  const terminalRef = useRef("null");
+  const terminalRef = useRef(null);
 
   const handleCommand = async (command, ...args) => {
     const fullCommand = [command, ...args].join(" ");
     console.log("Full Command:", fullCommand);
     try {
-      const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
+      const { data } = await axios.post(`${API_BASE_URL}/gdb_command`, {
         command: fullCommand,
         name: "program",
       });


### PR DESCRIPTION
## Summary
Replaced hardcoded `http://127.0.0.1:10000` API base URL across 
all components with a `VITE_API_BASE_URL` environment variable.

## Changes
- Added `API_BASE_URL` constant using `import.meta.env.VITE_API_BASE_URL` 
  with fallback to localhost in 6 components
- Fixed `useRef("null")` → `useRef(null)` in TerminalComp.jsx
- Renamed hardcoded `data` arrays to `hardcodedData` to avoid 
  variable name conflicts
- Added missing `key` props in all `.map()` functions
- Added `.env.example` for developer reference

## Files Changed
- Stack.jsx
- Functions.jsx
- TerminalComp.jsx
- Breakpoint.jsx
- BreakPoints.jsx
- MemoryMap.jsx

## Fixes
Closes #83
Closes #115