### PR TITLE
✨ Enhancement: Add Visual Loading Spinners for Long-Running GDB Commands

### DIFF
--- a/webapp/src/App.test.jsx
+++ b/webapp/src/App.test.jsx
@@ -25,7 +25,7 @@ test("renders Threads component within Debug route", () => {
       </DataProvider>
     </MemoryRouter>
   );
-  const threadsComponent = screen.getByText(/Threads/i);
+  const threadsComponent = screen.getByText("No active threads.");
   expect(threadsComponent).toBeInTheDocument();
   // Add any other checks specific to the Threads component
 });

--- a/webapp/src/components/DebugHeader/DebugHeader.css
+++ b/webapp/src/components/DebugHeader/DebugHeader.css
@@ -97,3 +97,16 @@ body {
   border-radius: 2px;
   background: var(--primary-orange, #e88f40);
 }
+
+.rotating-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/webapp/src/components/DebugHeader/DebugHeader.jsx
+++ b/webapp/src/components/DebugHeader/DebugHeader.jsx
@@ -4,6 +4,7 @@ import {
   FaArrowRight,
   FaForward,
   FaSquare,
+  FaSpinner
 } from "react-icons/fa6";
 import { IoReload } from "react-icons/io5";
 import { MdSkipNext, MdSkipPrevious } from "react-icons/md";
@@ -19,9 +20,11 @@ const DebugHeader = () => {
     setTerminalOutput,
     setCommandPress,
     commandPress,
+    isLoading
   } = DataState();
 
   const handleRun = (command) => {
+    if (isLoading) return;
     console.log("clicked");
     setCommandPress(!commandPress);
     setTerminalOutput(command);
@@ -31,66 +34,74 @@ const DebugHeader = () => {
     <div className="parent-debug-header">
       <div className="debug-header">
         <div className="icons">
-          <div className="arrow">
-            <FaArrowLeft
-              className="icon"
-              title="Previous"
-              onClick={() => {
-                handleRun("previous");
-              }}
-            />
-            <FaArrowRight
-              className="icon"
-              title="Next"
-              onClick={() => {
-                handleRun("next");
-              }}
-            />
-          </div>
-          <div className="others">
-            <IoReload
-              className="icon"
-              title="Run"
-              onClick={() => {
-                handleRun("run");
-              }}
-            />
-            <FaForward
-              className="icon"
-              title="Continue"
-              onClick={() => {
-                handleRun("continue");
-              }}
-            />
-            <FaSquare
-              className="icon"
-              title="Stop"
-              onClick={() => {
-                handleRun("stop");
-              }}
-            />
-            <MdSkipNext
-              className="icon"
-              title="Step"
-              onClick={() => {
-                handleRun("step");
-              }}
-            />
-            <MdSkipPrevious
-              className="icon"
-              title="Finish"
-              onClick={() => {
-                handleRun("finish");
-              }}
-            />
-            <BsArrowRightSquareFill
-              className="icon"
-              title="Run"
-              onClick={() => {
-                handleRun("step-out");
-              }}
-            />
-          </div>
+          {isLoading ? (
+            <div className="others">
+              <FaSpinner className="icon rotating-spinner" title="Loading..." />
+            </div>
+          ) : (
+            <>
+              <div className="arrow">
+                <FaArrowLeft
+                  className="icon"
+                  title="Previous"
+                  onClick={() => {
+                    handleRun("previous");
+                  }}
+                />
+                <FaArrowRight
+                  className="icon"
+                  title="Next"
+                  onClick={() => {
+                    handleRun("next");
+                  }}
+                />
+              </div>
+              <div className="others">
+                <IoReload
+                  className="icon"
+                  title="Run"
+                  onClick={() => {
+                    handleRun("run");
+                  }}
+                />
+                <FaForward
+                  className="icon"
+                  title="Continue"
+                  onClick={() => {
+                    handleRun("continue");
+                  }}
+                />
+                <FaSquare
+                  className="icon"
+                  title="Stop"
+                  onClick={() => {
+                    handleRun("stop");
+                  }}
+                />
+                <MdSkipNext
+                  className="icon"
+                  title="Step"
+                  onClick={() => {
+                    handleRun("step");
+                  }}
+                />
+                <MdSkipPrevious
+                  className="icon"
+                  title="Finish"
+                  onClick={() => {
+                    handleRun("finish");
+                  }}
+                />
+                <BsArrowRightSquareFill
+                  className="icon"
+                  title="Run"
+                  onClick={() => {
+                    handleRun("step-out");
+                  }}
+                />
+              </div>
+            </>
+          )}
         </div>
         <div className="filename">
           <div className="filename-content">filename</div>

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -5,13 +5,14 @@ import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
 
 const TerminalComp = () => {
-  const { terminalOutput, commandPress } = DataState();
+  const { terminalOutput, commandPress, setIsLoading } = DataState();
   const [output, setOutput] = useState("");
   const terminalRef = useRef("null");
 
   const handleCommand = async (command, ...args) => {
     const fullCommand = [command, ...args].join(" ");
     console.log("Full Command:", fullCommand);
+    setIsLoading(true);
     try {
       const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
         command: fullCommand,
@@ -20,6 +21,8 @@ const TerminalComp = () => {
       return data["result"];
     } catch (error) {
       return "Error executing command";
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -18,6 +18,7 @@ export const DataProvider = ({ children }) => {
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
   const [commandPress, setCommandPress] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (refresh) {
@@ -56,9 +57,11 @@ export const DataProvider = ({ children }) => {
         dark,
         setDark,
         terminalOutput,
-        setCommandPress,
-        commandPress,
         setTerminalOutput,
+        commandPress,
+        setCommandPress,
+        isLoading,
+        setIsLoading,
       }}
     >
       {children}


### PR DESCRIPTION
# ✨ Enhancement: Add Visual "Loading" Spinners for Long-Running GDB Commands (#127)

This Pull Request fixes #127.

## **Description**

Previously, when a user clicked any execution control button (Run, Reverse, Next) in the `DebugHeader`, the frontend immediately fired off the `axios` request to the GDB backend but provided **zero visual feedback**. This caused users to think the application was broken, resulting in them clicking the buttons multiple times and spamming the backend with duplicate GDB directives.

This PR solves the problem by introducing asynchronous UI state management during GDB executions.

- Added a global `isLoading` boolean state to the root `DataContext.jsx`.
- Wrapped the `<TerminalComp />` Axios cycle with `setIsLoading(true)` on initialization and `setIsLoading(false)` on resolution or exception.
- Updated `DebugHeader.jsx` to intercept clicks when `isLoading === true`, effectively disabling rapid presses.
- Implemented a sleek, rotating `<FaSpinner />` CSS animation that temporarily replaces the debug controls while the backend thinks, providing immediate, explicit feedback.

- ***

### **Additional context**
cc: @charithccmc @Ammoniya ready for review!
