### PR TITLE
refactor: centralize API URL configuration

### DIFF
--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -4,6 +4,7 @@ import "./Breakpoint.css";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import axios from "axios";
+import API_BASE_URL from "../../config";
 
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
@@ -18,7 +19,7 @@ const Breakpoint = () => {
       return;
     }
     try {
-      const data = await axios.post("http://127.0.0.1:10000/set_breakpoint", {
+      const data = await axios.post(`${API_BASE_URL}/set_breakpoint`, {
         location: breakLine,
         name: "program",
       });

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Functions.css";
 import axios from "axios";
+import API_BASE_URL from "../../config";
 
 const data = [
   "sub.KERNEL32.dll_DeleteCritical_231",
@@ -22,7 +23,7 @@ const Functions = () => {
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+      const data = await axios.post(`${API_BASE_URL}/get_locals`, {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
 import axios from "axios";
+import API_BASE_URL from "../../../config";
 
 const data = [
   {
@@ -26,7 +27,7 @@ const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
   const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+    const data = await axios.post(`${API_BASE_URL}/info_breakpoints`, {
       name: "program",
     });
     console.log(data.data["result"]);

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -3,6 +3,7 @@ import { DataState } from "./../../../context/DataContext";
 
 import "./MemoryMap.css";
 import axios from "axios";
+import API_BASE_URL from "../../../config";
 
 const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
@@ -19,7 +20,7 @@ const MemoryMap = () => {
 
   const fetchMemoryMap = async () => {
     console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+    const data = await axios.post(`${API_BASE_URL}/memory_map`, {
       name: "program",
     });
     console.log(data.data.result);

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { DataState } from "./../../context/DataContext";
 import "./Stack.css";
 import axios from "axios";
+import API_BASE_URL from "../../config";
 
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
@@ -9,7 +10,7 @@ const Stack = () => {
   const fetStackData = async () => {
     try {
       console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+      const data = await axios.post(`${API_BASE_URL}/stack_trace`, {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -3,6 +3,7 @@ import { ReactTerminal } from "react-terminal";
 import axios from "axios";
 import "./Terminal.css";
 import { DataState } from "../../context/DataContext";
+import API_BASE_URL from "../../config";
 
 const TerminalComp = () => {
   const { terminalOutput, commandPress } = DataState();
@@ -13,7 +14,7 @@ const TerminalComp = () => {
     const fullCommand = [command, ...args].join(" ");
     console.log("Full Command:", fullCommand);
     try {
-      const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
+      const { data } = await axios.post(`${API_BASE_URL}/gdb_command`, {
         command: fullCommand,
         name: "program",
       });

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -1,0 +1,3 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:10000';
+
+export default API_BASE_URL;


### PR DESCRIPTION
## Problem
The frontend currently has hardcoded API URLs (`http://127.0.0.1:10000`) in 6 different components, making it impossible to deploy the application to different environments (staging, production) or configure the backend URL dynamically.

## Solution
- Created centralized configuration file (`webapp/src/config.js`)
- Replaced all hardcoded API URLs with the centralized constant
- Added support for environment variable override via `VITE_API_URL`

## Benefits
- **Enables deployment**: Frontend and backend can be deployed on different servers
- **Supports CI/CD**: Different API URLs can be configured per environment in build pipelines
- **Prepares for multiuser support**: Backend can be scaled independently
- **Maintains backward compatibility**: Defaults to `localhost:10000` for local development

## Changes
- Added: `webapp/src/config.js`
- Modified: 6 component files to use centralized config
  - `Breakpoint.jsx`
  - `Functions.jsx`
  - `BreakPoints.jsx`
  - `MemoryMap.jsx`
  - `Stack.jsx`
  - `TerminalComp.jsx`

## Testing
- [x] Tested locally with default configuration
- [x] Verified API calls reach backend successfully
- [x] No breaking changes to existing functionality

## Related to Future Goals
This change directly supports the project's roadmap for:
- First deployment
- CI/CD integration
- Multiuser support architecture
