### PR TITLE
fix(server): clean up gdb sessions in tests and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To run the backend tests, use the following procedure:
 3. Run the tests using the `unittest` module:
 
     ```sh
-    python -m unittest discover -s tests
+    python -m unittest discover -s . -p 'flask_test.py'
     ```
 
 ## Contributing
@@ -144,4 +144,3 @@ We welcome contributions from the community! To get started:
 ## Design
 
 https://www.figma.com/proto/flJ4HBaH4QhF18RSKGOWwA/GDB-UI?type=design&node-id=111-1101&t=sDAc1dWc1LAfqpaT-0&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=111%3A2956
-

--- a/gdbui_server/flask_test.py
+++ b/gdbui_server/flask_test.py
@@ -5,7 +5,7 @@ from flask import Flask
 from flask_testing import TestCase
 from unittest import mock
 from io import BytesIO
-from main import app
+from main import app, close_gdb_session
 import os
 
 class TestGDBRoutes(TestCase):
@@ -14,6 +14,7 @@ class TestGDBRoutes(TestCase):
         return app
 
     def setUp(self):
+        close_gdb_session()
         self.temp_dir = tempfile.TemporaryDirectory()
 
         compile_payload = {
@@ -23,6 +24,7 @@ class TestGDBRoutes(TestCase):
         self.client.post('/compile', data=json.dumps(compile_payload), content_type='application/json')
 
     def tearDown(self):
+        close_gdb_session()
         self.temp_dir.cleanup()
 
 

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -3,6 +3,7 @@ from pygdbmi.gdbcontroller import GdbController
 from flask_cors import CORS
 import subprocess
 import os
+import atexit
 
 app = Flask(__name__)
 cors = CORS(app)
@@ -10,6 +11,30 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 
 gdb_controller = None
 program_name = None
+
+def close_gdb_session():
+    global gdb_controller, program_name
+
+    if gdb_controller is None:
+        program_name = None
+        return
+
+    try:
+        gdb_controller.exit()
+    except Exception:
+        # Fallback for partially initialized controllers.
+        gdb_process = getattr(gdb_controller, "gdb_process", None)
+        if gdb_process is not None:
+            try:
+                gdb_process.terminate()
+                gdb_process.wait(timeout=1)
+            except Exception:
+                pass
+    finally:
+        gdb_controller = None
+        program_name = None
+
+atexit.register(close_gdb_session)
 
 def execute_gdb_command(command):
     response2 = gdb_controller.write(command)
@@ -25,10 +50,12 @@ def ensure_exe_extension(name):
 
 def start_gdb_session(program):
     global gdb_controller, program_name
+    close_gdb_session()
     program_name = program
     try:
         gdb_controller = GdbController()
     except Exception as e:
+        close_gdb_session()
         raise RuntimeError(f"Failed to initialize GDB controller: {e}")
 
     try:
@@ -36,6 +63,7 @@ def start_gdb_session(program):
         if response is None:
             raise RuntimeError("No response from GDB controller")
     except Exception as e:
+        close_gdb_session()
         raise RuntimeError(f"Failed to set program file: {e}")
     
     try:
@@ -43,6 +71,7 @@ def start_gdb_session(program):
         if response is None:
             raise RuntimeError("No response from GDB controller")
     except Exception as e:
+        close_gdb_session()
         raise RuntimeError(f"Failed to start program: {e}")
 
 @app.route('/gdb_command', methods=['POST'])
@@ -72,7 +101,6 @@ def gdb_command():
 
 @app.route('/compile', methods=['POST'])
 def compile_code():
-    global program_name
     data = request.get_json()
     code = data.get('code')
     name = data.get('name')
@@ -83,7 +111,7 @@ def compile_code():
     result = subprocess.run(['g++', f'{name}.cpp', '-o', f'output/{name}.exe'], capture_output=True, text=True)
 
     if result.returncode == 0:
-        program_name = None
+        close_gdb_session()
         return jsonify({'success': True, 'output': 'Compilation successful.'})
     else:
         return jsonify({'success': False, 'output': result.stderr})


### PR DESCRIPTION
## Description

This PR fixes resource/process leakage in backend test/runtime GDB session handling.

Fixes #140

### What changed
- Added explicit `close_gdb_session()` lifecycle helper.
- Registered cleanup on process exit via `atexit`.
- Closed previous session before starting a new GDB session.
- Closed session on start failures and after successful compile reset.
- Added cleanup calls in backend test `setUp`/`tearDown`.

### Validation
- `gdbui_server/env/bin/python -m unittest discover -s gdbui_server -p 'flask_test.py'`
- Result: `Ran 20 tests ... OK`.

### Risk
Scope is limited to GDB controller lifecycle management and test cleanup hooks.
