### PR TITLE
Fix: Remove deprecated version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+
 services:
   gdbui_server:
     build:


### PR DESCRIPTION
This PR removes the deprecated version field from docker-compose.yml 
to align with the latest Docker Compose specification.

Closes #81