### PR TITLE
Fix api base url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+
 services:
   gdbui_server:
     build:

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:10000

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -22,7 +22,7 @@ const Functions = () => {
   const fetchFunctionsData = async () => {
     try {
       console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+      const data = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/get_locals`, {
         name: "program",
       });
       console.log(data.data.result);

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -26,7 +26,7 @@ const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
   const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+    const data = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/get_locals`, {
       name: "program",
     });
     console.log(data.data["result"]);

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -19,7 +19,7 @@ const MemoryMap = () => {
 
   const fetchMemoryMap = async () => {
     console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+    const data = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/get_locals`, {
       name: "program",
     });
     console.log(data.data.result);

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,6 +1,6 @@
 // main.jsx
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { DataProvider } from "./context/DataContext";
 import { TerminalContextProvider } from "react-terminal";
@@ -8,4 +8,14 @@ import App from "./App";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(
+  <BrowserRouter>
+    <DataProvider>
+      <TerminalContextProvider>
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      </TerminalContextProvider>
+    </DataProvider>
+  </BrowserRouter>
+);

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -7,15 +7,5 @@ import { TerminalContextProvider } from "react-terminal";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.render(
-  <BrowserRouter>
-    <DataProvider>
-      <TerminalContextProvider>
-        <React.StrictMode>
-          <App />
-        </React.StrictMode>
-      </TerminalContextProvider>
-    </DataProvider>
-  </BrowserRouter>,
-  document.getElementById("root")
-);
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);


### PR DESCRIPTION
### Replace Hardcoded Backend URLs with Environment Variable

#### Summary

This PR removes hardcoded backend API URLs from the frontend code and replaces them with an environment variable. This improves flexibility and makes the application easier to configure across different environments.

#### Changes Made

* Replaced hardcoded URLs like:

  `http://127.0.0.1:10000/...`

  with:

  `\${import.meta.env.VITE_API_BASE_URL}/...`

* Added support for configuring the backend base URL through a `.env` file.

#### Example

Old:
`axios.post("http://127.0.0.1:10000/get_locals", {...})`

New:
`axios.post(\`${import.meta.env.VITE_API_BASE_URL}/get_locals`, {...})`

#### Reason

Hardcoding API endpoints makes the application difficult to deploy in different environments (development, staging, production). Using environment variables allows the backend URL to be configured without modifying the source code.

#### Result

* Improves maintainability
* Makes the frontend configuration more flexible
* Supports different deployment environments

#### Related Issue

Resolves the issue regarding replacing hardcoded API base URLs with environment variables.
