### PR TITLE
feat: add GitHub Actions CI workflow for frontend and backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend:
+    name: Frontend Tests (React)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: webapp
+        run: npm install
+
+      - name: Run frontend tests
+        working-directory: webapp
+        run: npm run test
+
+  backend:
+    name: Backend Tests (Python)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install backend dependencies
+        working-directory: gdbui_server
+        run: pip install -r requirements.txt
+
+      - name: Run backend tests
+        working-directory: gdbui_server
+        run: python -m unittest discover -s tests


### PR DESCRIPTION

## What does this PR do?
Adds a GitHub Actions CI workflow that automatically runs 
frontend and backend tests on every push and pull request to main.

## Why is this needed?

Currently there is no automated testing pipeline. This means:
- PRs can be merged without verifying tests pass
- No automated build check for React frontend
- No automated test run for Python backend

## Changes Made
- Added `.github/workflows/ci.yml`
- Frontend job: sets up Node.js 18, installs deps, runs tests
- Backend job: sets up Python 3.10, installs deps, runs unittest

## How to Test
- Push any commit to main or open a PR
- Check the Actions tab on GitHub to see CI running

## Related Issue
This directly addresses the GSoC 2026 "CI/CD Integration" milestone




---