### PR TITLE
feat: add session status indicator and connection badge to UI

### DIFF
--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -3,6 +3,7 @@ from pygdbmi.gdbcontroller import GdbController
 from flask_cors import CORS
 import subprocess
 import os
+import uuid
 
 app = Flask(__name__)
 cors = CORS(app)
@@ -231,6 +232,12 @@ def health():
     return jsonify({
         'success': True,
         'status': 'alive'
+    })
+
+@app.route('/create_session', methods=['POST'])
+def create_session():
+    return jsonify({
+        'session_id': str(uuid.uuid4())
     })
 
 @app.route('/get_locals', methods=['POST'])

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -226,6 +226,13 @@ def get_registers():
     
     return jsonify(response)
 
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({
+        'success': True,
+        'status': 'alive'
+    })
+
 @app.route('/get_locals', methods=['POST'])
 def get_locals():
     global program_name

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -9,9 +9,11 @@ import BreakPoints from "./components/GdbComponents/BreakPoints/BreakPoints";
 import Footer from "./components/Footer/Footer";
 import Header from "./components/Header/Header";
 import { DataState } from "./context/DataContext";
+import useSession from "./hooks/useSession";
 
 const App = () => {
   const { setDark, dark, isDarkMode, setDarkMode } = DataState();
+  useSession();
 
   const toggleDarkMode = () => {
     setDarkMode((isDarkMode) => (isDarkMode === "dark" ? "light" : "dark"));

--- a/webapp/src/components/Header/Header.jsx
+++ b/webapp/src/components/Header/Header.jsx
@@ -3,6 +3,7 @@ import "./Header.css";
 import c2si from "../../assets/c2si.png";
 import { Link } from "react-router-dom";
 import { DarkModeSwitch } from "react-toggle-dark-mode";
+import SessionBadge from "../SessionBadge/SessionBadge";
 
 const Header = ({ isDarkMode, toggleDarkMode, dark }) => {
   return (
@@ -12,6 +13,7 @@ const Header = ({ isDarkMode, toggleDarkMode, dark }) => {
           <img src={c2si} alt="C2si" />
         </div>
         <div className="login">
+          <SessionBadge />
           <div className="darkmode">
             <DarkModeSwitch
               style={{ marginBottom: "2rem" }}

--- a/webapp/src/components/SessionBadge/SessionBadge.css
+++ b/webapp/src/components/SessionBadge/SessionBadge.css
@@ -1,0 +1,41 @@
+.session-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: var(--header-bg, #2a2a2a);
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-color, #fff);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-right: 15px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-connected {
+  background-color: #4caf50;
+  box-shadow: 0 0 5px #4caf50;
+}
+
+.status-connecting {
+  background-color: #ffc107;
+  box-shadow: 0 0 5px #ffc107;
+}
+
+.status-disconnected {
+  background-color: #f44336;
+  box-shadow: 0 0 5px #f44336;
+}
+
+.session-id {
+  opacity: 0.8;
+  font-family: monospace;
+  margin-left: 4px;
+}

--- a/webapp/src/components/SessionBadge/SessionBadge.jsx
+++ b/webapp/src/components/SessionBadge/SessionBadge.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { DataState } from "../../context/DataContext";
+import "./SessionBadge.css";
+
+const SessionBadge = () => {
+  const { sessionId, connectionStatus } = DataState();
+
+  const getStatusClass = () => {
+    switch (connectionStatus) {
+      case "Connected":
+        return "status-connected";
+      case "Connecting...":
+        return "status-connecting";
+      default:
+        return "status-disconnected";
+    }
+  };
+
+  const displayId = sessionId ? sessionId.substring(0, 8) : "";
+
+  return (
+    <div className="session-badge">
+      <div className={`status-dot ${getStatusClass()}`}></div>
+      <span className="status-text">{connectionStatus}</span>
+      {connectionStatus === "Connected" && displayId && (
+        <span className="session-id">#{displayId}</span>
+      )}
+    </div>
+  );
+};
+
+export default SessionBadge;

--- a/webapp/src/components/SessionBadge/__tests__/SessionBadge.test.jsx
+++ b/webapp/src/components/SessionBadge/__tests__/SessionBadge.test.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import SessionBadge from "../SessionBadge";
+import { DataContext } from "../../../context/DataContext";
+
+describe("SessionBadge", () => {
+  it("renders status mapping and session id visibility from context", () => {
+    const { rerender } = render(
+      <DataContext.Provider
+        value={{
+          sessionId: "abcd1234-efgh-5678",
+          connectionStatus: "Connecting...",
+        }}
+      >
+        <SessionBadge />
+      </DataContext.Provider>,
+    );
+
+    expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    expect(screen.queryByText("#abcd1234")).not.toBeInTheDocument();
+    expect(document.querySelector(".status-dot")).toHaveClass(
+      "status-connecting",
+    );
+
+    rerender(
+      <DataContext.Provider
+        value={{
+          sessionId: "abcd1234-efgh-5678",
+          connectionStatus: "Connected",
+        }}
+      >
+        <SessionBadge />
+      </DataContext.Provider>,
+    );
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText("#abcd1234")).toBeInTheDocument();
+    expect(document.querySelector(".status-dot")).toHaveClass(
+      "status-connected",
+    );
+
+    rerender(
+      <DataContext.Provider
+        value={{
+          sessionId: "abcd1234-efgh-5678",
+          connectionStatus: "Disconnected",
+        }}
+      >
+        <SessionBadge />
+      </DataContext.Provider>,
+    );
+
+    expect(screen.getByText("Disconnected")).toBeInTheDocument();
+    expect(screen.queryByText("#abcd1234")).not.toBeInTheDocument();
+    expect(document.querySelector(".status-dot")).toHaveClass(
+      "status-disconnected",
+    );
+  });
+});

--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -18,6 +18,8 @@ export const DataProvider = ({ children }) => {
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
   const [commandPress, setCommandPress] = useState(true);
+  const [sessionId, setSessionId] = useState(null);
+  const [connectionStatus, setConnectionStatus] = useState("Disconnected");
 
   const fetchData = useCallback(async () => {
     if (refresh) {
@@ -59,6 +61,10 @@ export const DataProvider = ({ children }) => {
         setCommandPress,
         commandPress,
         setTerminalOutput,
+        sessionId,
+        setSessionId,
+        connectionStatus,
+        setConnectionStatus,
       }}
     >
       {children}

--- a/webapp/src/hooks/__tests__/useSession.test.jsx
+++ b/webapp/src/hooks/__tests__/useSession.test.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import useSession from "../useSession";
+import { DataContext } from "../../context/DataContext";
+
+const HookHarness = () => {
+  useSession();
+  return null;
+};
+
+const flushMicrotasks = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe("useSession", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("creates backend session, updates connection state, and polls every 5 seconds", async () => {
+    const setSessionId = vi.fn();
+    const setConnectionStatus = vi.fn();
+
+    global.fetch = vi.fn((url) => {
+      if (url.endsWith("/create_session")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ session_id: "abcd1234-efgh-5678" }),
+        });
+      }
+
+      if (url.endsWith("/health")) {
+        return Promise.resolve({ ok: true });
+      }
+
+      return Promise.reject(new Error("Unexpected URL"));
+    });
+
+    const { unmount } = render(
+      <DataContext.Provider
+        value={{
+          setSessionId,
+          setConnectionStatus,
+        }}
+      >
+        <HookHarness />
+      </DataContext.Provider>,
+    );
+
+    expect(setConnectionStatus).toHaveBeenCalledWith("Connecting...");
+
+    await flushMicrotasks();
+    expect(setSessionId).toHaveBeenCalledWith("abcd1234-efgh-5678");
+    expect(setConnectionStatus).toHaveBeenCalledWith("Connected");
+
+    const getHealthCallCount = () =>
+      global.fetch.mock.calls.filter(([url]) => url.endsWith("/health")).length;
+
+    expect(getHealthCallCount()).toBe(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicrotasks();
+    expect(getHealthCallCount()).toBe(2);
+
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(getHealthCallCount()).toBe(2);
+  });
+});

--- a/webapp/src/hooks/useSession.js
+++ b/webapp/src/hooks/useSession.js
@@ -1,29 +1,49 @@
 import { useEffect } from "react";
 import { DataState } from "../context/DataContext";
 
+const POLL_INTERVAL = 5000;
+
 const useSession = () => {
-  const { setSessionId, setConnectionStatus } = DataState();
+  const { sessionId, setSessionId, setConnectionStatus } = DataState();
+  const apiBaseUrl =
+    import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:10000";
 
   useEffect(() => {
-    // Generate UUID if it doesn't exist
-    const generateId = () => {
-      return (
-        crypto.randomUUID?.() ||
-        Math.random().toString(36).substring(2, 15) +
-        Math.random().toString(36).substring(2, 15)
-      );
-    };
-    setSessionId(prev => prev ?? generateId());
+    if (sessionId) {
+      return;
+    }
 
+    const createSession = async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}/create_session`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+        if (!response.ok) {
+          throw new Error("Failed to create session");
+        }
+        const data = await response.json();
+        setSessionId(data?.session_id ?? null);
+      } catch {
+        setSessionId(null);
+      }
+    };
+
+    createSession();
+  }, [apiBaseUrl, sessionId, setSessionId]);
+
+  useEffect(() => {
     const checkConnection = async () => {
       try {
-        const response = await fetch("http://127.0.0.1:10000/health");
+        const response = await fetch(`${apiBaseUrl}/health`);
         if (response.ok) {
           setConnectionStatus("Connected");
         } else {
           setConnectionStatus("Disconnected");
         }
-      } catch (error) {
+      } catch {
         setConnectionStatus("Disconnected");
       }
     };
@@ -34,10 +54,10 @@ const useSession = () => {
     // Re-check every 5 seconds
     const interval = setInterval(() => {
       checkConnection();
-    }, 5000);
+    }, POLL_INTERVAL);
 
     return () => clearInterval(interval);
-  }, [setSessionId, setConnectionStatus]);
+  }, [apiBaseUrl, setConnectionStatus]);
 };
 
 export default useSession;

--- a/webapp/src/hooks/useSession.js
+++ b/webapp/src/hooks/useSession.js
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { DataState } from "../context/DataContext";
+
+const useSession = () => {
+  const { setSessionId, setConnectionStatus } = DataState();
+
+  useEffect(() => {
+    // Generate UUID if it doesn't exist
+    const generateId = () => {
+      return (
+        crypto.randomUUID?.() ||
+        Math.random().toString(36).substring(2, 15) +
+        Math.random().toString(36).substring(2, 15)
+      );
+    };
+    setSessionId(prev => prev ?? generateId());
+
+    const checkConnection = async () => {
+      try {
+        const response = await fetch("http://127.0.0.1:10000/health");
+        if (response.ok) {
+          setConnectionStatus("Connected");
+        } else {
+          setConnectionStatus("Disconnected");
+        }
+      } catch (error) {
+        setConnectionStatus("Disconnected");
+      }
+    };
+
+    setConnectionStatus("Connecting...");
+    checkConnection();
+
+    // Re-check every 5 seconds
+    const interval = setInterval(() => {
+      checkConnection();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [setSessionId, setConnectionStatus]);
+};
+
+export default useSession;


### PR DESCRIPTION
Closes #143

## Changes
- `SessionBadge.jsx` — color-coded badge (🟢 Connected / 🟡 Connecting / 🔴 Disconnected)
- `useSession.js` — real backend health check polling every 5 seconds  
- `DataContext.jsx` — sessionId + connectionStatus added for future multiuser work
- `main.py` — /health GET endpoint added for clean connection status checks

## Testing
- Badge shows 🟡 Connecting on page load
- Badge shows 🟢 Connected when backend is running
- Badge shows 🔴 Disconnected when backend is down
- Auto re-checks every 5 seconds