### PR TITLE
fix: resolve race conditions and memory leaks in useEffect data fetching

### DIFF
--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -19,24 +19,29 @@ const data = [
 const Functions = () => {
   const { refresh, functions, setFunctions } = DataState();
 
-  const fetchFunctionsData = async () => {
-    try {
-      console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setFunctions(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   useEffect(() => {
-    if (refresh) {
-      fetchFunctionsData();
-    }
-  }, [refresh]);
+    if (!refresh) return;
+
+    const controller = new AbortController();
+
+    const fetchFunctionsData = async () => {
+      try {
+        const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+          name: "program",
+        }, { signal: controller.signal });
+        setFunctions(data.data.result);
+      } catch (error) {
+        if (!axios.isCancel(error)) {
+          console.error("Functions fetch failed:", error);
+        }
+      }
+    };
+
+    fetchFunctionsData();
+
+    return () => controller.abort();
+  }, [refresh, setFunctions]);
 
   return (
     <div className="functions-parent">

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -25,19 +25,29 @@ const data = [
 const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
-  const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
-      name: "program",
-    });
-    console.log(data.data["result"]);
-    setInfoBreakpointData(data.data["result"]);
-  };
+
   useEffect(() => {
-    if (refresh) {
-      console.log("click from breakpoint in GdbComponents");
-      fetchInfoBreakpoints();
-    }
-  }, [refresh]);
+    if (!refresh) return;
+
+    const controller = new AbortController();
+
+    const fetchInfoBreakpoints = async () => {
+      try {
+        const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
+          name: "program",
+        }, { signal: controller.signal });
+        setInfoBreakpointData(data.data["result"]);
+      } catch (error) {
+        if (!axios.isCancel(error)) {
+          console.error("Breakpoints fetch failed:", error);
+        }
+      }
+    };
+
+    fetchInfoBreakpoints();
+
+    return () => controller.abort();
+  }, [refresh, setInfoBreakpointData]);
   return (
     <div>
       {/* BreakPoints */}

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -17,18 +17,29 @@ const data = [
 const MemoryMap = () => {
   const { refresh, memoryMap, setMemoryMap } = DataState();
 
-  const fetchMemoryMap = async () => {
-    console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
-      name: "program",
-    });
-    console.log(data.data.result);
-    setMemoryMap(data.data.result);
-  };
 
   useEffect(() => {
-    if (refresh) fetchMemoryMap();
-  }, [refresh]);
+    if (!refresh) return;
+
+    const controller = new AbortController();
+
+    const fetchMemoryMap = async () => {
+      try {
+        const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+          name: "program",
+        }, { signal: controller.signal });
+        setMemoryMap(data.data.result);
+      } catch (error) {
+        if (!axios.isCancel(error)) {
+          console.error("Memory map fetch failed:", error);
+        }
+      }
+    };
+
+    fetchMemoryMap();
+
+    return () => controller.abort();
+  }, [refresh, setMemoryMap]);
 
   return (
     <div>

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -6,21 +6,29 @@ import axios from "axios";
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
 
-  const fetStackData = async () => {
-    try {
-      console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setStack(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+
   useEffect(() => {
-    if (refresh) fetStackData();
-  }, [refresh]);
+    if (!refresh) return;
+
+    const controller = new AbortController();
+
+    const fetStackData = async () => {
+      try {
+        const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+          name: "program",
+        }, { signal: controller.signal });
+        setStack(data.data.result);
+      } catch (error) {
+        if (!axios.isCancel(error)) {
+          console.error("Stack fetch failed:", error);
+        }
+      }
+    };
+
+    fetStackData();
+
+    return () => controller.abort();
+  }, [refresh, setStack]);
   return (
     <div className="stack-parent">
       <div className="stack-heading">Stack</div>


### PR DESCRIPTION
Closes #157

## Problem
When stepping through GDB rapidly, multiple concurrent axios requests 
fire without cancellation. A delayed response can overwrite fresh UI 
data with stale data. Also causes memory leak when component unmounts 
mid-request.

## Affected Files
- Stack.jsx
- BreakPoints.jsx
- Functions.jsx
- MemoryMap.jsx

## Fix
- Added AbortController to all 4 components
- Cleanup function cancels inflight requests on unmount
- Guard clause prevents API calls when refresh is false
- Removed duplicate outer async functions

## Testing
- No console.log statements ✅
- No duplicate functions ✅
- Cleanup function returns controller.abort() ✅