### PR TITLE
Fixed bug: race condition and memory leak in useEffect data fetching

### DIFF
--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -19,23 +19,42 @@ const data = [
 const Functions = () => {
   const { refresh, functions, setFunctions } = DataState();
 
-  const fetchFunctionsData = async () => {
-    try {
-      console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setFunctions(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
   useEffect(() => {
-    if (refresh) {
-      fetchFunctionsData();
-    }
+    if (!refresh) return;
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const fetchFunctionsData = async () => {
+      try {
+        console.log("click from functions");
+        const data = await axios.post(
+          "http://127.0.0.1:10000/get_locals",
+          {
+            name: "program",
+          },
+          { signal }
+        );
+        if (!signal.aborted) {
+          console.log(data.data.result);
+          setFunctions(data.data.result);
+        }
+      } catch (error) {
+        if (
+          error?.name !== "AbortError" &&
+          error?.name !== "CanceledError" &&
+          error?.code !== "ERR_CANCELED"
+        ) {
+          console.log(error);
+        }
+      }
+    };
+
+    fetchFunctionsData();
+
+    return () => {
+      controller.abort();
+    };
   }, [refresh]);
 
   return (

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -25,18 +25,42 @@ const data = [
 const BreakPoints = () => {
   const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
 
-  const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
-      name: "program",
-    });
-    console.log(data.data["result"]);
-    setInfoBreakpointData(data.data["result"]);
-  };
   useEffect(() => {
-    if (refresh) {
-      console.log("click from breakpoint in GdbComponents");
-      fetchInfoBreakpoints();
-    }
+    if (!refresh) return;
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const fetchInfoBreakpoints = async () => {
+      try {
+        const data = await axios.post(
+          "http://127.0.0.1:10000/info_breakpoints",
+          {
+            name: "program",
+          },
+          { signal }
+        );
+        if (!signal.aborted) {
+          console.log(data.data["result"]);
+          setInfoBreakpointData(data.data["result"]);
+        }
+      } catch (error) {
+        if (
+          error?.name !== "AbortError" &&
+          error?.name !== "CanceledError" &&
+          error?.code !== "ERR_CANCELED"
+        ) {
+          console.error("Fetch failed:", error);
+        }
+      }
+    };
+
+    console.log("click from breakpoint in GdbComponents");
+    fetchInfoBreakpoints();
+
+    return () => {
+      controller.abort();
+    };
   }, [refresh]);
   return (
     <div>

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -17,17 +17,42 @@ const data = [
 const MemoryMap = () => {
   const { refresh, memoryMap, setMemoryMap } = DataState();
 
-  const fetchMemoryMap = async () => {
-    console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
-      name: "program",
-    });
-    console.log(data.data.result);
-    setMemoryMap(data.data.result);
-  };
-
   useEffect(() => {
-    if (refresh) fetchMemoryMap();
+    if (!refresh) return;
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const fetchMemoryMap = async () => {
+      try {
+        console.log("Click form memory map");
+        const data = await axios.post(
+          "http://127.0.0.1:10000/memory_map",
+          {
+            name: "program",
+          },
+          { signal }
+        );
+        if (!signal.aborted) {
+          console.log(data.data.result);
+          setMemoryMap(data.data.result);
+        }
+      } catch (error) {
+        if (
+          error?.name !== "AbortError" &&
+          error?.name !== "CanceledError" &&
+          error?.code !== "ERR_CANCELED"
+        ) {
+          console.error("Fetch failed:", error);
+        }
+      }
+    };
+
+    fetchMemoryMap();
+
+    return () => {
+      controller.abort();
+    };
   }, [refresh]);
 
   return (

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -6,20 +6,42 @@ import axios from "axios";
 const Stack = () => {
   const { refresh, stack, setStack } = DataState();
 
-  const fetStackData = async () => {
-    try {
-      console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setStack(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
   useEffect(() => {
-    if (refresh) fetStackData();
+    if (!refresh) return;
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const fetStackData = async () => {
+      try {
+        console.log("click from stack");
+        const data = await axios.post(
+          "http://127.0.0.1:10000/stack_trace",
+          {
+            name: "program",
+          },
+          { signal }
+        );
+        if (!signal.aborted) {
+          console.log(data.data.result);
+          setStack(data.data.result);
+        }
+      } catch (error) {
+        if (
+          error?.name !== "AbortError" &&
+          error?.name !== "CanceledError" &&
+          error?.code !== "ERR_CANCELED"
+        ) {
+          console.log(error);
+        }
+      }
+    };
+
+    fetStackData();
+
+    return () => {
+      controller.abort();
+    };
   }, [refresh]);
   return (
     <div className="stack-parent">

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -9,18 +9,33 @@ const TerminalComp = () => {
   const [output, setOutput] = useState("");
   const terminalRef = useRef("null");
 
-  const handleCommand = async (command, ...args) => {
-    const fullCommand = [command, ...args].join(" ");
+  const executeCommand = async (fullCommand, signal) => {
     console.log("Full Command:", fullCommand);
     try {
-      const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
-        command: fullCommand,
-        name: "program",
-      });
+      const { data } = await axios.post(
+        "http://127.0.0.1:10000/gdb_command",
+        {
+          command: fullCommand,
+          name: "program",
+        },
+        signal ? { signal } : undefined
+      );
       return data["result"];
     } catch (error) {
+      if (
+        error?.name === "AbortError" ||
+        error?.name === "CanceledError" ||
+        error?.code === "ERR_CANCELED"
+      ) {
+        return null;
+      }
       return "Error executing command";
     }
+  };
+
+  const handleCommand = async (command, ...args) => {
+    const fullCommand = [command, ...args].join(" ");
+    return executeCommand(fullCommand);
   };
 
   const defaultHandler = async (command, ...args) => {
@@ -30,11 +45,24 @@ const TerminalComp = () => {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const runTerminalCommand = async () => {
+      if (!terminalOutput) return;
+      const result = await executeCommand(terminalOutput, signal);
+      if (!signal.aborted && result !== null) {
+        setOutput(result);
+      }
+    };
+
     console.log(terminalOutput);
-    if (terminalOutput) {
-      console.log(terminalOutput);
-      defaultHandler(terminalOutput);
-    }
+    if (terminalOutput) console.log(terminalOutput);
+    runTerminalCommand();
+
+    return () => {
+      controller.abort();
+    };
   }, [commandPress]);
 
   return (


### PR DESCRIPTION
# **Fixed bug: race condition and memory leak in useEffect data fetching **

This PR fixes #157

## What I changed

- Updated webapp/src/components/Stack/Stack.jsx
- Updated webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx Updated webapp/src/components/Functions/Functions.jsx Updated webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx Also updated webapp/src/components/Terminal/TerminalComp.jsx after searching for other useEffect-triggered API requests
- 

## Fix pattern applied
For each affected useEffect with API calls:

- Created a new AbortController per effect run
- Passed signal into the request (axios.post(..., { signal }))
- Added cleanup return () => controller.abort() to cancel in-flight request on dependency change/unmount
- Guarded state updates with if (!signal.aborted) so aborted/stale responses cannot update UI
- Ignored abort/cancel errors (AbortError / CanceledError / ERR_CANCELED) and only logged real failures

## Result

- Prevents delayed older responses from overwriting newer state
- Prevents state updates after unmount (memory leak warning case)
- Keeps existing UI behavior and state shape unchanged (only fetching logic was touched)