### PR TITLE
fix: replace broken test_compile_code and add compile failure test

### DIFF
--- a/gdbui_server/.gitignore
+++ b/gdbui_server/.gitignore
@@ -22,3 +22,7 @@ ENV/
 lib/
 lib64/
 include/
+
+# Compiled test artifacts
+*.cpp
+*.exe

--- a/gdbui_server/flask_test.py
+++ b/gdbui_server/flask_test.py
@@ -27,33 +27,58 @@ class TestGDBRoutes(TestCase):
 
 
     def test_compile_code(self):
-        with mock.patch('os.makedirs') as mock_makedirs:
-            with mock.patch.object(self.client, 'post') as mock_post:
-            
-                mock_response = mock.Mock()
-                mock_response.status_code = 200
-                mock_response.json = {'output': 'Compilation successful', 'success': True}
-                mock_post.return_value = mock_response
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
 
-                output_dir = os.path.join(self.temp_dir.name, 'output')
+        with mock.patch('subprocess.run', return_value=mock_result) as mock_run:
+            payload = {
+                "code": '#include <iostream>\nint main() { std::cout << "Hello"; return 0; }',
+                "name": "test_compile_success",
+            }
+            response = self.client.post(
+                '/compile',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
 
-                if not os.path.exists(output_dir):
-                    os.makedirs(output_dir)  
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.json['success'])
+            self.assertEqual(response.json['output'], 'Compilation successful.')
 
-                rel_output_dir = os.path.relpath(output_dir, self.temp_dir.name)
-                rel_output_dir = rel_output_dir.replace("\\", "/")  
+            mock_run.assert_called_once_with(
+                ['g++', 'test_compile_success.cpp', '-o', 'output/test_compile_success.exe'],
+                capture_output=True,
+                text=True
+            )
 
-                payload = {
-                    "code": '#include <iostream>\nint main() { std::cout << "Hello, Universe!"; return 0; }',
-                    "name": f"test_program2",  
-                }
+        if os.path.exists('test_compile_success.cpp'):
+            os.remove('test_compile_success.cpp')
 
-                response = self.client.post('/compile', data=json.dumps(payload), content_type='application/json')
-                
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue(response.json['success'])
+    def test_compile_code_failure(self):
+        mock_result = mock.Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "error: expected ';' after expression"
 
-                mock_makedirs.assert_called_with(output_dir)
+        with mock.patch('subprocess.run', return_value=mock_result):
+            payload = {
+                "code": "int main() { return 0 }",
+                "name": "test_compile_fail",
+            }
+            response = self.client.post(
+                '/compile',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(response.json['success'])
+            self.assertIn("expected ';'", response.json['output'])
+
+        if os.path.exists('test_compile_fail.cpp'):
+            os.remove('test_compile_fail.cpp')
 
         
     def test_gdb_command(self):


### PR DESCRIPTION
Fixes #161
---
## Description
test_compile_code in gdbui_server/flask_test.py was mocking self.client.post which is the Flask test client itself. This meant 
the actual /compile route handler never ran during the test. The test was only checking that a mock returned what it was set up to return, so it would always pass regardless of what the real code does.

## Changes

Fixed by mocking subprocess.run instead and sending a real request through Flask, which now exercises JSON parsing, file writing, and response building.

Added test_compile_code_failure to cover the g++ non-zero exit code path (lines 88-89 in main.py), which had zero test coverage.

Added *.cpp and *.exe to gdbui_server/.gitignore to prevent compiled test artifacts from being accidentally committed.

## Testing

python3 -m unittest flask_test.TestGDBRoutes.test_compile_code -v passes
python3 -m unittest flask_test.TestGDBRoutes.test_compile_code_failure -v passes
Full test suite (python3 -m unittest flask_test -v) passes with 21/21 tests
