### PR TITLE
refactor(context): simplify refresh handling

### DIFF
--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useState,
-  useEffect,
-  useCallback,
-  useContext,
-} from "react";
+import React, { createContext, useState, useContext } from "react";
 
 export const DataContext = createContext();
 
@@ -18,25 +12,6 @@ export const DataProvider = ({ children }) => {
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
   const [commandPress, setCommandPress] = useState(true);
-
-  const fetchData = useCallback(async () => {
-    if (refresh) {
-      try {
-        setRefresh(false);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-        setRefresh(false);
-      }
-    }
-  }, [refresh]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  const runCommandInTerminal = (command) => {
-    setTerminalOutput(command);
-  };
 
   return (
     <DataContext.Provider


### PR DESCRIPTION
## Summary

The `fetchData` function in `DataContext` was doing nothing useful — it just flipped `refresh` back to false inside a try/catch that could never actually throw. This created a pointless `useEffect` → `useCallback` → state update cycle on every refresh toggle without fetching any data.

Removed `fetchData` and the `useEffect` that called it. The context now just exposes `refresh` and `setRefresh` as plain state, and individual components own their own fetch behavior when the flag changes. Also dropped the unused `useCallback` and `useEffect` imports since nothing in the file needs them anymore.

## How to test

- `cd webapp && npm run test` — all Vitest suites pass
- `cd webapp && npm run build` — Vite builds successfully
- `cd gdbui_server && python -m unittest discover -s . -p 'flask_test.py'`
  — all backend tests pass
- Open the app and confirm panels that use `refresh` still update
  correctly when debug commands are triggered

## Related Issue

Fixes #163 

## Notes