### PR TITLE
Simplify refresh handling by removing DataContext fetch abstraction

### DIFF
--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -17,26 +17,28 @@ const data = [
 ];
 
 const Functions = () => {
-  const { refresh, functions, setFunctions } = DataState();
-
-  const fetchFunctionsData = async () => {
-    try {
-      console.log("click from functions");
-      const data = await axios.post("http://127.0.0.1:10000/get_locals", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setFunctions(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { refresh, setRefresh, functions, setFunctions } = DataState();
 
   useEffect(() => {
-    if (refresh) {
-      fetchFunctionsData();
-    }
-  }, [refresh]);
+    if (!refresh) return;
+
+    const fetchData = async () => {
+      try {
+        console.log("click from functions");
+        const data = await axios.post("http://127.0.0.1:10000/get_locals", {
+          name: "program",
+        });
+        console.log(data.data.result);
+        setFunctions(data.data.result);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setRefresh((prev) => (prev ? false : prev));
+      }
+    };
+
+    fetchData();
+  }, [refresh, setRefresh, setFunctions]);
 
   return (
     <div className="functions-parent">

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { DataState } from "./../../../context/DataContext";
 import "./BreakPoints.css";
 import axios from "axios";
@@ -23,21 +23,32 @@ const data = [
 ];
 
 const BreakPoints = () => {
-  const { refresh, setInfoBreakpointData, infoBreakpointData } = DataState();
+  const { refresh, setRefresh, setInfoBreakpointData, infoBreakpointData } =
+    DataState();
 
-  const fetchInfoBreakpoints = async () => {
-    const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
-      name: "program",
-    });
-    console.log(data.data["result"]);
-    setInfoBreakpointData(data.data["result"]);
-  };
   useEffect(() => {
-    if (refresh) {
-      console.log("click from breakpoint in GdbComponents");
-      fetchInfoBreakpoints();
-    }
-  }, [refresh]);
+    if (!refresh) return;
+
+    const fetchData = async () => {
+      try {
+        console.log("click from breakpoint in GdbComponents");
+        const data = await axios.post(
+          "http://127.0.0.1:10000/info_breakpoints",
+          {
+            name: "program",
+          }
+        );
+        console.log(data.data["result"]);
+        setInfoBreakpointData(data.data["result"]);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setRefresh((prev) => (prev ? false : prev));
+      }
+    };
+
+    fetchData();
+  }, [refresh, setRefresh, setInfoBreakpointData]);
   return (
     <div>
       {/* BreakPoints */}

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -15,20 +15,28 @@ const data = [
   "0x7fffffffe270: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00",
 ];
 const MemoryMap = () => {
-  const { refresh, memoryMap, setMemoryMap } = DataState();
-
-  const fetchMemoryMap = async () => {
-    console.log("Click form memory map");
-    const data = await axios.post("http://127.0.0.1:10000/memory_map", {
-      name: "program",
-    });
-    console.log(data.data.result);
-    setMemoryMap(data.data.result);
-  };
+  const { refresh, setRefresh, memoryMap, setMemoryMap } = DataState();
 
   useEffect(() => {
-    if (refresh) fetchMemoryMap();
-  }, [refresh]);
+    if (!refresh) return;
+
+    const fetchData = async () => {
+      try {
+        console.log("Click form memory map");
+        const data = await axios.post("http://127.0.0.1:10000/memory_map", {
+          name: "program",
+        });
+        console.log(data.data.result);
+        setMemoryMap(data.data.result);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setRefresh((prev) => (prev ? false : prev));
+      }
+    };
+
+    fetchData();
+  }, [refresh, setRefresh, setMemoryMap]);
 
   return (
     <div>

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -4,23 +4,28 @@ import "./Stack.css";
 import axios from "axios";
 
 const Stack = () => {
-  const { refresh, stack, setStack } = DataState();
+  const { refresh, setRefresh, stack, setStack } = DataState();
 
-  const fetStackData = async () => {
-    try {
-      console.log("click from stack");
-      const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
-        name: "program",
-      });
-      console.log(data.data.result);
-      setStack(data.data.result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
   useEffect(() => {
-    if (refresh) fetStackData();
-  }, [refresh]);
+    if (!refresh) return;
+
+    const fetchData = async () => {
+      try {
+        console.log("click from stack");
+        const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
+          name: "program",
+        });
+        console.log(data.data.result);
+        setStack(data.data.result);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setRefresh((prev) => (prev ? false : prev));
+      }
+    };
+
+    fetchData();
+  }, [refresh, setRefresh, setStack]);
   return (
     <div className="stack-parent">
       <div className="stack-heading">Stack</div>

--- a/webapp/src/context/DataContext.jsx
+++ b/webapp/src/context/DataContext.jsx
@@ -1,8 +1,6 @@
 import React, {
   createContext,
   useState,
-  useEffect,
-  useCallback,
   useContext,
 } from "react";
 
@@ -18,25 +16,6 @@ export const DataProvider = ({ children }) => {
   const [memoryMap, setMemoryMap] = useState("");
   const [terminalOutput, setTerminalOutput] = useState("");
   const [commandPress, setCommandPress] = useState(true);
-
-  const fetchData = useCallback(async () => {
-    if (refresh) {
-      try {
-        setRefresh(false);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-        setRefresh(false);
-      }
-    }
-  }, [refresh]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  const runCommandInTerminal = (command) => {
-    setTerminalOutput(command);
-  };
 
   return (
     <DataContext.Provider


### PR DESCRIPTION
Fixws issue #163 
## Description
This PR removes misleading refresh logic from DataContext and makes refresh-triggered API fetching local to each consumer component.

## What changed

- Removed fetchData from DataContext (it did not fetch anything and only reset refresh).
- Removed useEffect/useCallback in DataContext that were tied to that function.
- Kept refresh and setRefresh as the shared signal mechanism.
- Updated refresh consumers to own their own refresh fetch logic:
        - Stack
        - BreakPoints
        - Functions
        - MemoryMap
        
        
- Standardized each component to:

- early-return when refresh is false
- perform existing API call locally
- reset refresh in finally to avoid stuck refresh state
- Removed dead/unused imports related to the old abstraction.

## Additional context

- UI behavior is unchanged: Save/refresh still triggers data reloads.
- This reduces unnecessary indirection and avoids the impression that DataContext is responsible for data fetching.
- Added safe reset behavior (setRefresh(prev => prev ? false : prev)) to prevent conflicts when multiple components complete around the same time.