### PR TITLE
feat(breakpoints): add watchpoint input to breakpoint panel

### DIFF
--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -8,6 +8,7 @@ import axios from "axios";
 const Breakpoint = () => {
   const [breakLine, setBreakLine] = useState("");
   const [breakFunction, setBreakFunction] = useState("");
+  const [watchVariable, setWatchVariable] = useState("");
 
   const handleBreakSave = async (e) => {
     e.preventDefault();
@@ -26,6 +27,30 @@ const Breakpoint = () => {
       toast.success("Added breakpoint", {
         autoClose: 1000,
       });
+    } catch (error) {
+      toast.error("Something went Wrong", {
+        autoClose: 1000,
+      });
+    }
+  };
+
+  const handleWatchpointSave = async (e) => {
+    e.preventDefault();
+    if (!watchVariable) {
+      toast.error("Enter a variable to watch", {
+        autoClose: 1000,
+      });
+      return;
+    }
+    try {
+      await axios.post("http://127.0.0.1:10000/add_watchpoint", {
+        variable: watchVariable,
+        name: "program",
+      });
+      toast.success("Added watchpoint", {
+        autoClose: 1000,
+      });
+      setWatchVariable("");
     } catch (error) {
       toast.error("Something went Wrong", {
         autoClose: 1000,
@@ -58,6 +83,19 @@ const Breakpoint = () => {
         </div>
         <button className="save-button" onClick={handleBreakSave}>
           Add
+        </button>
+      </div>
+      <div className="lower-breakpoint">
+        <div className="line-breakpoint">
+          <a>Watch variable</a>
+          <input
+            type="text"
+            value={watchVariable}
+            onChange={(e) => setWatchVariable(e.target.value)}
+          />
+        </div>
+        <button className="save-button" onClick={handleWatchpointSave}>
+          Add watchpoint
         </button>
       </div>
       <ToastContainer

--- a/webapp/src/components/Breakpoint/__tests__/Breakpoint.test.jsx
+++ b/webapp/src/components/Breakpoint/__tests__/Breakpoint.test.jsx
@@ -9,8 +9,11 @@ test("renders Breakpoint component with basic structure", () => {
   const addBreakpointElement = screen.getByText(/Add Breakpoint/i);
   expect(addBreakpointElement).toBeInTheDocument();
 
+  const watchLabel = screen.getByText(/Watch variable/i);
+  expect(watchLabel).toBeInTheDocument();
+
   const lineInputs = screen.getAllByRole("textbox");
-  expect(lineInputs).toHaveLength(2);
+  expect(lineInputs).toHaveLength(3);
 });
 
 test("renders Breakpoint component and checks about text Line", async () => {
@@ -26,4 +29,14 @@ test("typing in Line input updates the value correctly", () => {
   fireEvent.change(lineInput[0], { target: { value: "123" } });
 
   expect(lineInput[0]).toHaveValue("123");
+});
+
+test("typing in Watch variable input updates the value correctly", () => {
+  render(<Breakpoint />);
+
+  const textInputs = screen.getAllByRole("textbox");
+  const watchInput = textInputs[2];
+  fireEvent.change(watchInput, { target: { value: "myVar" } });
+
+  expect(watchInput).toHaveValue("myVar");
 });


### PR DESCRIPTION
## PR Summary

The `/add_watchpoint` endpoint existed on the backend but had no UI.
I added a watch expression input alongside the existing breakpoint form so you can finally set watchpoints from the browser. It sends the expression to the backend and shows a toast on success or validation failure.

## How to test

Open the app, go to the Break Points panel, type a variable name into the watch input and hit add. Confirm the request hits `/add_watchpoint` and a toast appears. Try submitting empty to confirm the validationmessage shows.

## Related Issue

Fixes #166 

## Notes

`npm run lint` still reports the same pre-existing ESLint errors as
before — nothing new introduced by this change.