### PR TITLE
fix: remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gdbui_server:
     build:


### PR DESCRIPTION
## Summary
Removes the deprecated `version` field from docker-compose.yml.

## Problem
The `version` field is obsolete in recent versions of Docker Compose 
and generates the following warning on every run:

the attribute `version` is obsolete, it will be ignored, please remove 
it to avoid potential confusion

## Solution
Removed the `version: "3"` line from docker-compose.yml.

Fixes #81