### PR TITLE
chore: add .dockerignore to optimize Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+venv/
+*.egg-info/
+
+# Node
+node_modules/
+npm-debug.log
+
+# Build output
+build/
+dist/
+
+# Environment files
+.env
+.env.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/


### PR DESCRIPTION
This PR fixes #69

## **Description**

- Added a `.dockerignore` file to prevent unnecessary files from being 
  copied into the Docker build context.
- Excludes Python virtual environments (`venv/`, `__pycache__`, `*.pyc`)
- Excludes Node dependencies (`node_modules/`)
- Excludes Git metadata (`.git/`)
- Excludes environment files (`.env`)
- Excludes OS and IDE specific files (`.DS_Store`, `.vscode/`)

### **Additional context**

- Without this file, Docker copies the entire project including dependencies 
  and cache files, making builds unnecessarily slow and images larger.
- This is a zero-risk change that only affects Docker build performance.