### PR TITLE
fix: remove deprecated version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gdbui_server:
     build:


### PR DESCRIPTION
## Description
The `version` field in `docker-compose.yml` is deprecated in recent 
versions of Docker Compose and generates unnecessary warnings. 
Removing it makes the configuration cleaner and forward-compatible.

Fixes #59

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings