### PR TITLE
 ci(webapp): add lint and build steps to webapp CI   workflow

### DIFF
--- a/.github/workflows/run-test-for-webapp.yml
+++ b/.github/workflows/run-test-for-webapp.yml
@@ -34,3 +34,14 @@ jobs:
         run: |
           cd webapp
           npx vitest --coverage.enabled true
+
+      - name: Run npm lint
+        continue-on-error: true
+        run: |
+          cd webapp
+          npm run lint
+
+      - name: Run npm build
+        run: |
+          cd webapp
+          npm run build


### PR DESCRIPTION
## Summary

The webapp CI workflow only ran tests — a PR that broke the build or introduced lint errors would ship green. Added two steps
  after the existing test step:

  - Lint runs npm run lint with continue-on-error: true because there are pre-existing lint errors in the repo unrelated to any individual PR. This way lint output is visible in CI without blocking merges until those are cleaned up separately.
  - Build runs npm run build and must pass. A broken build now blocks merges.

  **How to test**

  - Open a PR against main and check the Run NPM Tests on Pull Request workflow run
  - Lint step should appear and report results (may show warnings/errors from pre-existing issues) without failing the job
  - Build step should appear and pass; introduce a syntax error to verify it fails and blocks the merge

FIxes #181 