### PR TITLE
feat(backend): add health endpoint and docker-compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - "10000:10000"
     expose:
       - 10000
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:10000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   webapp:
     build:
@@ -22,3 +28,6 @@ services:
       - "5173:5173"
     expose:
       - 5173
+    depends_on:
+      gdbui_server:
+        condition: service_healthy

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -445,5 +445,10 @@ def delete_breakpoint():
     return jsonify(response)
 
 
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({'status': 'ok'})
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=10000)


### PR DESCRIPTION
## Summary

The backend had no health endpoint and docker-compose had no startup ordering, so the frontend could start making API calls before Flask was ready to accept connections.

Added a GET /health route to main.py and wired it into docker-compose:

- `gdbui_server/main.py` — new GET /health returning `{"status": "ok"}`
- `docker-compose.yml` — healthcheck on gdbui_server using Python's urllib since curl is not available in the slim image; 10s interval, 5s timeout, 5 retries, 10s start period
- `docker-compose.yml` — depends_on with condition: service_healthy
  on webapp so it only starts once the backend passes its healthcheck

## How to test

- Run `docker-compose up --build -d` from the repo root
- Watch startup order — gdbui_server will show healthy before webapp starts
- `curl http://localhost:10000/health` returns `{"status": "ok"}`

 ## Related Issue
Fixes #183

## Notes
N/A