### PR TITLE
fix: Remove debug console.log statements from production components #155

### DIFF
--- a/webapp/src/components/Breakpoint/Breakpoint.jsx
+++ b/webapp/src/components/Breakpoint/Breakpoint.jsx
@@ -22,7 +22,6 @@ const Breakpoint = () => {
         location: breakLine,
         name: "program",
       });
-      console.log(data);
       toast.success("Added breakpoint", {
         autoClose: 1000,
       });

--- a/webapp/src/components/DebugHeader/DebugHeader.jsx
+++ b/webapp/src/components/DebugHeader/DebugHeader.jsx
@@ -22,7 +22,6 @@ const DebugHeader = () => {
   } = DataState();
 
   const handleRun = (command) => {
-    console.log("clicked");
     setCommandPress(!commandPress);
     setTerminalOutput(command);
   };

--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -21,14 +21,12 @@ const Functions = () => {
 
   const fetchFunctionsData = async () => {
     try {
-      console.log("click from functions");
       const data = await axios.post("http://127.0.0.1:10000/get_locals", {
         name: "program",
       });
-      console.log(data.data.result);
       setFunctions(data.data.result);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   };
 

--- a/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
+++ b/webapp/src/components/GdbComponents/BreakPoints/BreakPoints.jsx
@@ -29,12 +29,10 @@ const BreakPoints = () => {
     const data = await axios.post("http://127.0.0.1:10000/info_breakpoints", {
       name: "program",
     });
-    console.log(data.data["result"]);
     setInfoBreakpointData(data.data["result"]);
   };
   useEffect(() => {
     if (refresh) {
-      console.log("click from breakpoint in GdbComponents");
       fetchInfoBreakpoints();
     }
   }, [refresh]);

--- a/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
+++ b/webapp/src/components/GdbComponents/MemoryMap/MemoryMap.jsx
@@ -18,11 +18,9 @@ const MemoryMap = () => {
   const { refresh, memoryMap, setMemoryMap } = DataState();
 
   const fetchMemoryMap = async () => {
-    console.log("Click form memory map");
     const data = await axios.post("http://127.0.0.1:10000/memory_map", {
       name: "program",
     });
-    console.log(data.data.result);
     setMemoryMap(data.data.result);
   };
 

--- a/webapp/src/components/Stack/Stack.jsx
+++ b/webapp/src/components/Stack/Stack.jsx
@@ -8,14 +8,12 @@ const Stack = () => {
 
   const fetStackData = async () => {
     try {
-      console.log("click from stack");
       const data = await axios.post("http://127.0.0.1:10000/stack_trace", {
         name: "program",
       });
-      console.log(data.data.result);
       setStack(data.data.result);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   };
   useEffect(() => {

--- a/webapp/src/components/Terminal/TerminalComp.jsx
+++ b/webapp/src/components/Terminal/TerminalComp.jsx
@@ -11,7 +11,6 @@ const TerminalComp = () => {
 
   const handleCommand = async (command, ...args) => {
     const fullCommand = [command, ...args].join(" ");
-    console.log("Full Command:", fullCommand);
     try {
       const { data } = await axios.post("http://127.0.0.1:10000/gdb_command", {
         command: fullCommand,
@@ -30,9 +29,7 @@ const TerminalComp = () => {
   };
 
   useEffect(() => {
-    console.log(terminalOutput);
     if (terminalOutput) {
-      console.log(terminalOutput);
       defaultHandler(terminalOutput);
     }
   }, [commandPress]);


### PR DESCRIPTION
# **Fix: Remove debug console.log statements from production components**
<!-- This PR fixes #155 -->

## **Description**
- Removed 15 `console.log` statements from 7 production React components
- Files changed: `Breakpoint.jsx`, `TerminalComp.jsx`, `Stack.jsx`, `DebugHeader.jsx`, `Functions.jsx`, `MemoryMap.jsx`, `BreakPoints.jsx`
- Replaced `console.log(error)` in catch blocks with `console.error(error)` for proper error handling
- No test files were modified

### **Additional context**
