### PR TITLE
fix: add input validation for /gdb_command endpoint

### DIFF
--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -49,8 +49,21 @@ def start_gdb_session(program):
 def gdb_command():
     global program_name
     data = request.get_json()
+    if not data:
+        return jsonify({'success': False, 'error': 'Request body must be valid JSON'}), 400
+
     command = data.get('command')
     file = data.get('name')
+
+    if not command or not isinstance(command, str) or not command.strip():
+        return jsonify({'success': False, 'error': 'Missing or invalid command field'}), 400
+
+    if not file or not isinstance(file, str) or not file.strip():
+        return jsonify({'success': False, 'error': 'Missing or invalid name field'}), 400
+
+    command = command.strip()
+    file = file.strip()
+
     if program_name != file:
         start_gdb_session(f'{file}')
 


### PR DESCRIPTION
**Description:**
```
## Description
The `/gdb_command` endpoint accepted requests with missing or invalid 
`command` and `name` fields, which could cause silent failures or 
unexpected behavior when null/empty values were passed to GDB.

Added validation to check:
- Request body is valid JSON
- `command` field is present, a string, and non-empty
- `name` field is present, a string, and non-empty
- Both fields are stripped of whitespace before processing

Fixes #88

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings