### PR TITLE
fix: correct application port from 3000 to 5173 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The quickest way to get started with GDB-UI is by using Docker. A `docker-compos
     docker-compose up
     ```
 
-This command will build and start both the frontend and backend services, making the application available at [http://localhost:3000](http://localhost:3000) (or your specified port).
+This command will build and start both the frontend and backend services, making the application available at [http://localhost:5173](http://localhost:5173) (or your specified port).
+backend API runs on (http://localhost:10000)
 
 ### Manual Setup
 


### PR DESCRIPTION

# Name of PR => Changed Port in Readme.md
This PR fixes issue in Readme file 

## **Description**

Fixed incorrect port number in README setup instructions.
  The README stated the application is available at `localhost:3000`,
  but `docker-compose.yml` maps the webapp service to port `5173:5173`.
  Port 3000 is not used anywhere in the project.

- Changed: `localhost:3000` → `localhost:5173`
- Also noted backend API runs on `localhost:10000` as defined in docker-compose.yml

- ***

### **Additional context**

Verified by checking docker-compose.yml:
- webapp service: ports 5173:5173
- gdbui_server service: ports 10000:10000
Port 3000 is not mapped anywhere in the project configuration.
