### PR TITLE
fix(tests): add missing vi import to Stack.test.jsx

### DIFF
--- a/webapp/src/components/Stack/__tests__/Stack.test.jsx
+++ b/webapp/src/components/Stack/__tests__/Stack.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import Stack from "../Stack.jsx";
 
 vi.mock("../../../context/DataContext.jsx", () => ({


### PR DESCRIPTION
## Summary

`Stack.test.jsx` was using `vi.mock()` and `vi.fn()` without importing `vi` from vitest, causing the entire test file to throw a `ReferenceError: vi is not defined` at runtime. No test in that file could ever run — it was silently producing zero results rather than a visible failure. Added the missing `import { vi } from "vitest"` to match how `Functions.test.jsx` already does it.

## How to test
  - `cd webapp && npx vitest run src/components/Stack/__tests__/Stack.test.jsx`
  - Before: `ReferenceError: vi is not defined`, 0 tests run
  - After: 1 test passes cleanly