### PR TITLE
fix(ui): remove stray offset text node from Functions panel

### DIFF
--- a/webapp/src/components/Functions/Functions.jsx
+++ b/webapp/src/components/Functions/Functions.jsx
@@ -41,7 +41,6 @@ const Functions = () => {
   return (
     <div className="functions-parent">
       <a className="functions-heading"> Functions</a>
-      offset
       <div className="functions">
         {functions}
         {data.map((obj) => {


### PR DESCRIPTION
## Summary

The Functions panel was rendering the word "offset" as visible plain text between the heading and the list. It was a bare JSX text node --- not a comment, not inside any element — left over from a layout placeholder that was never removed. Deleted the single line.

## How to test

- Start the app and open the Functions panel (Debug view → Functions tab)
- Before: the word "offset" appears as unstyled plain text below the "Functions" heading
- After: no stray text, heading goes directly into the list container
