### PR TITLE
chore: run dev containers as non-root users

### DIFF
--- a/gdbui_server/DockerFile.dev
+++ b/gdbui_server/DockerFile.dev
@@ -3,6 +3,9 @@ FROM python:3.10-slim
 # Set the working directory
 WORKDIR /app
 
+# Create a non-root user and group for runtime
+RUN groupadd --system appgroup && useradd --system --gid appgroup --create-home appuser
+
 # Copy only the requirements file first to leverage Docker cache
 COPY requirements.txt .
 
@@ -14,6 +17,11 @@ RUN apt-get update && apt-get install -y gdb
 
 # Copy the rest of the application code
 COPY . .
+
+# Ensure runtime directories are writable by the app user
+RUN mkdir -p /app/output && chown -R appuser:appgroup /app
+
+USER appuser
 
 # Command to run the backend server
 CMD ["python", "main.py"]

--- a/webapp/DockerFile.dev
+++ b/webapp/DockerFile.dev
@@ -12,6 +12,11 @@ RUN npm install
 # Copy the rest of the application code
 COPY . .
 
+# Use the non-root node user provided by the base image
+RUN chown -R node:node /app
+
+USER node
+
 # Expose the port the frontend runs on
 EXPOSE 5173
 


### PR DESCRIPTION
Run dev containers as non-root users

## **Description**

- Added non-root runtime users in backend and webapp dev Dockerfiles.
- Set writable ownership for backend app/output paths, then switched runtime to `USER` non-root.
- Kept startup commands unchanged to preserve dev workflow.

### **Additional context**

All test cases pass

```bash
docker build -f gdbui_server/DockerFile.dev -t gdbui-server:issue-71 gdbui_server  # pass
docker build -f webapp/DockerFile.dev -t gdbui-webapp:issue-71 webapp              # pass
docker run --rm gdbui-server:issue-71 id -u                                        # 999
docker run --rm gdbui-webapp:issue-71 id -u                                        # 1000
docker run --rm gdbui-server:issue-71 sh -lc 'python -c "from pathlib import Path; Path(\"output/_perm_test.tmp\").write_text(\"ok\"); print(\"ok\")"'  # ok
```