### PR TITLE
refactor: standardize API responses and remove internal command leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,81 @@ If you prefer a manual setup or are unable to use Docker, follow these steps:
     python main.py
     ```
 
+## Backend API
+
+The backend listens on `http://127.0.0.1:10000` by default.
+
+### Compatibility routes
+
+Existing unversioned routes keep the legacy response shape so current clients can continue reading top-level fields such as `result`, `output`, `message`, and `file_path`. Internal `code` fields are no longer returned.
+
+Example success response from `POST /gdb_command`:
+
+```json
+{
+  "success": true,
+  "result": "..."
+}
+```
+
+Example error response from `POST /gdb_command`:
+
+```json
+{
+  "success": false,
+  "error": "GDB command failed.",
+  "trace_id": "..."
+}
+```
+
+### V2 routes
+
+Every backend route is also available under `/v2` with the standardized response envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "result": "..."
+  }
+}
+```
+
+V2 errors return stable client-safe messages and codes. Exception details are logged server-side and correlated with `trace_id`.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "GDB_COMMAND_FAILED",
+    "message": "GDB command failed.",
+    "trace_id": "..."
+  }
+}
+```
+
+All responses include an `X-Correlation-ID` header. For V2 errors, the header value matches `error.trace_id`.
+
+Available V2 endpoints:
+
+- `POST /v2/compile`
+- `POST /v2/upload_file`
+- `POST /v2/gdb_command`
+- `POST /v2/set_breakpoint`
+- `POST /v2/info_breakpoints`
+- `POST /v2/stack_trace`
+- `POST /v2/threads`
+- `POST /v2/get_registers`
+- `POST /v2/get_locals`
+- `POST /v2/run`
+- `POST /v2/memory_map`
+- `POST /v2/continue`
+- `POST /v2/step_over`
+- `POST /v2/step_into`
+- `POST /v2/step_out`
+- `POST /v2/add_watchpoint`
+- `POST /v2/delete_breakpoint`
+
 ## Running Tests
 
 ### Frontend Tests (Vite)
@@ -95,16 +170,10 @@ To run the frontend tests, follow these steps:
 To run the backend tests, use the following procedure:
 
 1. Ensure your Python environment is set up as described in the manual setup.
-2. Navigate to the `gdbui_server` directory:
+2. From the repository root, run the tests using the `unittest` module:
 
     ```sh
-    cd gdbui_server
-    ```
-
-3. Run the tests using the `unittest` module:
-
-    ```sh
-    python -m unittest discover -s tests
+    python3 -m unittest discover -s gdbui_server -p "flask_test.py"
     ```
 
 ## Contributing
@@ -144,4 +213,3 @@ We welcome contributions from the community! To get started:
 ## Design
 
 https://www.figma.com/proto/flJ4HBaH4QhF18RSKGOWwA/GDB-UI?type=design&node-id=111-1101&t=sDAc1dWc1LAfqpaT-0&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=111%3A2956
-

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ V2 errors return stable client-safe messages and codes. Exception details are lo
 }
 ```
 
+V2 JSON endpoints validate required fields before running compiler or GDB actions. Missing or blank required fields return `400 Bad Request` with `error.code` set to `INVALID_REQUEST`.
+
 All responses include an `X-Correlation-ID` header. For V2 errors, the header value matches `error.trace_id`.
 
 Available V2 endpoints:

--- a/gdbui_server/flask_test.py
+++ b/gdbui_server/flask_test.py
@@ -13,7 +13,7 @@ class TestGDBRoutes(TestCase):
         app.config["TESTING"] = True
         return app
 
-    def assert_success_response(self, response):
+    def assert_v2_success_response(self, response):
         body = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(body["success"])
@@ -24,17 +24,41 @@ class TestGDBRoutes(TestCase):
         self.assertTrue(response.headers["X-Correlation-ID"])
         return body
 
-    def assert_error_response(self, response, expected_status):
+    def assert_v2_error_response(self, response, expected_status):
         body = json.loads(response.data)
         self.assertEqual(response.status_code, expected_status)
         self.assertFalse(body["success"])
         self.assertIn("error", body)
         self.assertNotIn("data", body)
         self.assertNotIn("code", body)
+        self.assertIn("code", body["error"])
         self.assertIn("message", body["error"])
         self.assertIn("trace_id", body["error"])
         self.assertIn("X-Correlation-ID", response.headers)
         self.assertEqual(body["error"]["trace_id"], response.headers["X-Correlation-ID"])
+        return body
+
+    def assert_legacy_success_response(self, response):
+        body = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(body["success"])
+        self.assertNotIn("data", body)
+        self.assertNotIn("error", body)
+        self.assertNotIn("code", body)
+        self.assertIn("X-Correlation-ID", response.headers)
+        self.assertTrue(response.headers["X-Correlation-ID"])
+        return body
+
+    def assert_legacy_error_response(self, response, expected_status, error_field="error"):
+        body = json.loads(response.data)
+        self.assertEqual(response.status_code, expected_status)
+        self.assertFalse(body["success"])
+        self.assertIn(error_field, body)
+        self.assertNotIn("data", body)
+        self.assertNotIn("code", body)
+        self.assertIn("trace_id", body)
+        self.assertIn("X-Correlation-ID", response.headers)
+        self.assertEqual(body["trace_id"], response.headers["X-Correlation-ID"])
         return body
 
     @mock.patch("main.subprocess.run")
@@ -45,8 +69,9 @@ class TestGDBRoutes(TestCase):
             "name": "test_program",
         }
 
-        response = self.client.post("/compile", data=json.dumps(payload), content_type="application/json")
-        body = self.assert_success_response(response)
+        with mock.patch("builtins.open", mock.mock_open()):
+            response = self.client.post("/v2/compile", data=json.dumps(payload), content_type="application/json")
+        body = self.assert_v2_success_response(response)
         self.assertEqual(body["data"]["output"], "Compilation successful.")
 
     @mock.patch("main.subprocess.run")
@@ -54,9 +79,25 @@ class TestGDBRoutes(TestCase):
         mock_run.return_value = mock.Mock(returncode=1, stderr="compile error")
         payload = {"code": "int main(){", "name": "bad_program"}
 
-        response = self.client.post("/compile", data=json.dumps(payload), content_type="application/json")
-        body = self.assert_error_response(response, 400)
-        self.assertIn("compile error", body["error"]["message"])
+        with mock.patch("builtins.open", mock.mock_open()):
+            response = self.client.post("/v2/compile", data=json.dumps(payload), content_type="application/json")
+        body = self.assert_v2_error_response(response, 400)
+        self.assertEqual(body["error"]["code"], "COMPILATION_FAILED")
+        self.assertEqual(body["error"]["message"], "Compilation failed.")
+        self.assertNotIn("compile error", json.dumps(body))
+
+    @mock.patch("main.subprocess.run")
+    def test_legacy_compile_schema(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0, stderr="")
+        payload = {
+            "code": '#include <iostream>\nint main() { std::cout << "Hello"; return 0; }',
+            "name": "test_program",
+        }
+
+        with mock.patch("builtins.open", mock.mock_open()):
+            response = self.client.post("/compile", data=json.dumps(payload), content_type="application/json")
+        body = self.assert_legacy_success_response(response)
+        self.assertEqual(body["output"], "Compilation successful.")
 
     @mock.patch("main.start_gdb_session")
     @mock.patch("main.execute_gdb_command")
@@ -84,13 +125,45 @@ class TestGDBRoutes(TestCase):
 
         for route, payload in route_payloads:
             with self.subTest(route=route):
-                response = self.client.post(route, data=json.dumps(payload), content_type="application/json")
-                body = self.assert_success_response(response)
+                response = self.client.post(f"/v2{route}", data=json.dumps(payload), content_type="application/json")
+                body = self.assert_v2_success_response(response)
                 self.assertIn("result", body["data"])
 
     @mock.patch("main.start_gdb_session")
     @mock.patch("main.execute_gdb_command")
+    def test_legacy_gdb_route_success_schema(self, mock_execute, mock_start):
+        mock_execute.return_value = "ok"
+        mock_start.return_value = None
+
+        response = self.client.post(
+            "/gdb_command",
+            data=json.dumps({"command": "info locals", "name": "program"}),
+            content_type="application/json",
+        )
+
+        body = self.assert_legacy_success_response(response)
+        self.assertEqual(body["result"], "ok")
+
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
     def test_gdb_route_error_schema(self, mock_execute, mock_start):
+        mock_execute.side_effect = RuntimeError("gdb boom")
+        mock_start.return_value = None
+
+        response = self.client.post(
+            "/v2/gdb_command",
+            data=json.dumps({"command": "info locals", "name": "program"}),
+            content_type="application/json",
+        )
+
+        body = self.assert_v2_error_response(response, 500)
+        self.assertEqual(body["error"]["code"], "GDB_COMMAND_FAILED")
+        self.assertEqual(body["error"]["message"], "GDB command failed.")
+        self.assertNotIn("gdb boom", json.dumps(body))
+
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
+    def test_legacy_gdb_route_error_schema(self, mock_execute, mock_start):
         mock_execute.side_effect = RuntimeError("gdb boom")
         mock_start.return_value = None
 
@@ -100,8 +173,9 @@ class TestGDBRoutes(TestCase):
             content_type="application/json",
         )
 
-        body = self.assert_error_response(response, 500)
-        self.assertIn("gdb boom", body["error"]["message"])
+        body = self.assert_legacy_error_response(response, 500)
+        self.assertEqual(body["error"], "GDB command failed.")
+        self.assertNotIn("gdb boom", json.dumps(body))
 
     @mock.patch("werkzeug.datastructures.FileStorage.save")
     def test_upload_file(self, mock_save):
@@ -110,35 +184,48 @@ class TestGDBRoutes(TestCase):
             "name": "test_program",
         }
 
-        response = self.client.post("/upload_file", content_type="multipart/form-data", data=data)
-        body = self.assert_success_response(response)
+        response = self.client.post("/v2/upload_file", content_type="multipart/form-data", data=data)
+        body = self.assert_v2_success_response(response)
         self.assertEqual(body["data"]["message"], "File uploaded successfully")
         self.assertEqual(body["data"]["file_path"], "output/test_program.exe")
         mock_save.assert_called_once()
 
+    @mock.patch("werkzeug.datastructures.FileStorage.save")
+    def test_legacy_upload_file(self, mock_save):
+        data = {
+            "file": (BytesIO(b"dummy file content"), "test_program"),
+            "name": "test_program",
+        }
+
+        response = self.client.post("/upload_file", content_type="multipart/form-data", data=data)
+        body = self.assert_legacy_success_response(response)
+        self.assertEqual(body["message"], "File uploaded successfully")
+        self.assertEqual(body["file_path"], "output/test_program.exe")
+        mock_save.assert_called_once()
+
     def test_upload_file_no_file(self):
         response = self.client.post(
-            "/upload_file", content_type="multipart/form-data", data={"name": "test_program"}
+            "/v2/upload_file", content_type="multipart/form-data", data={"name": "test_program"}
         )
-        body = self.assert_error_response(response, 400)
+        body = self.assert_v2_error_response(response, 400)
         self.assertIn("No file or name provided", body["error"]["message"])
 
     def test_upload_file_no_name(self):
         response = self.client.post(
-            "/upload_file",
+            "/v2/upload_file",
             content_type="multipart/form-data",
             data={"file": (BytesIO(b"dummy file content"), "test_program")},
         )
-        body = self.assert_error_response(response, 400)
+        body = self.assert_v2_error_response(response, 400)
         self.assertIn("No file or name provided", body["error"]["message"])
 
     def test_upload_file_empty_filename(self):
         response = self.client.post(
-            "/upload_file",
+            "/v2/upload_file",
             content_type="multipart/form-data",
             data={"file": (BytesIO(b"dummy file content"), ""), "name": "test_program"},
         )
-        body = self.assert_error_response(response, 400)
+        body = self.assert_v2_error_response(response, 400)
         self.assertIn("No selected file", body["error"]["message"])
 
 

--- a/gdbui_server/flask_test.py
+++ b/gdbui_server/flask_test.py
@@ -38,6 +38,12 @@ class TestGDBRoutes(TestCase):
         self.assertEqual(body["error"]["trace_id"], response.headers["X-Correlation-ID"])
         return body
 
+    def assert_v2_invalid_request(self, response, expected_message):
+        body = self.assert_v2_error_response(response, 400)
+        self.assertEqual(body["error"]["code"], "INVALID_REQUEST")
+        self.assertEqual(body["error"]["message"], expected_message)
+        return body
+
     def assert_legacy_success_response(self, response):
         body = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
@@ -87,6 +93,24 @@ class TestGDBRoutes(TestCase):
         self.assertNotIn("compile error", json.dumps(body))
 
     @mock.patch("main.subprocess.run")
+    def test_v2_compile_rejects_missing_payload(self, mock_run):
+        response = self.client.post("/v2/compile", content_type="application/json")
+
+        self.assert_v2_invalid_request(response, "Missing required fields: code, name.")
+        mock_run.assert_not_called()
+
+    @mock.patch("main.subprocess.run")
+    def test_v2_compile_rejects_blank_required_fields(self, mock_run):
+        response = self.client.post(
+            "/v2/compile",
+            data=json.dumps({"code": " ", "name": ""}),
+            content_type="application/json",
+        )
+
+        self.assert_v2_invalid_request(response, "Missing required fields: code, name.")
+        mock_run.assert_not_called()
+
+    @mock.patch("main.subprocess.run")
     def test_legacy_compile_schema(self, mock_run):
         mock_run.return_value = mock.Mock(returncode=0, stderr="")
         payload = {
@@ -128,6 +152,43 @@ class TestGDBRoutes(TestCase):
                 response = self.client.post(f"/v2{route}", data=json.dumps(payload), content_type="application/json")
                 body = self.assert_v2_success_response(response)
                 self.assertIn("result", body["data"])
+
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
+    def test_v2_gdb_command_rejects_missing_payload(self, mock_execute, mock_start):
+        response = self.client.post("/v2/gdb_command", content_type="application/json")
+
+        self.assert_v2_invalid_request(response, "Missing required fields: command, name.")
+        mock_start.assert_not_called()
+        mock_execute.assert_not_called()
+
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
+    def test_v2_gdb_routes_reject_missing_required_fields(self, mock_execute, mock_start):
+        route_payloads = [
+            ("/v2/set_breakpoint", {"name": "program"}, "Missing required fields: location."),
+            ("/v2/info_breakpoints", {}, "Missing required fields: name."),
+            ("/v2/stack_trace", {}, "Missing required fields: name."),
+            ("/v2/threads", {}, "Missing required fields: name."),
+            ("/v2/get_registers", {}, "Missing required fields: name."),
+            ("/v2/get_locals", {}, "Missing required fields: name."),
+            ("/v2/run", {}, "Missing required fields: name."),
+            ("/v2/memory_map", {}, "Missing required fields: name."),
+            ("/v2/continue", {}, "Missing required fields: name."),
+            ("/v2/step_over", {}, "Missing required fields: name."),
+            ("/v2/step_into", {}, "Missing required fields: name."),
+            ("/v2/step_out", {}, "Missing required fields: name."),
+            ("/v2/add_watchpoint", {"name": "program"}, "Missing required fields: variable."),
+            ("/v2/delete_breakpoint", {"breakpoint_number": 1}, "Missing required fields: name."),
+        ]
+
+        for route, payload, expected_message in route_payloads:
+            with self.subTest(route=route):
+                response = self.client.post(route, data=json.dumps(payload), content_type="application/json")
+                self.assert_v2_invalid_request(response, expected_message)
+
+        mock_start.assert_not_called()
+        mock_execute.assert_not_called()
 
     @mock.patch("main.start_gdb_session")
     @mock.patch("main.execute_gdb_command")

--- a/gdbui_server/flask_test.py
+++ b/gdbui_server/flask_test.py
@@ -1,251 +1,146 @@
-import unittest
 import json
-import tempfile
-from flask import Flask
-from flask_testing import TestCase
-from unittest import mock
+import unittest
 from io import BytesIO
+from unittest import mock
+
+from flask_testing import TestCase
+
 from main import app
-import os
+
 
 class TestGDBRoutes(TestCase):
     def create_app(self):
-        app.config['TESTING'] = True
+        app.config["TESTING"] = True
         return app
 
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-
-        compile_payload = {
-            "code": "#include <iostream>\nint main() { std::cout << 'Hello, World!'; return 0; }",
-            "name": f"{self.temp_dir.name}/test_program",
-        }
-        self.client.post('/compile', data=json.dumps(compile_payload), content_type='application/json')
-
-    def tearDown(self):
-        self.temp_dir.cleanup()
-
-
-    def test_compile_code(self):
-        with mock.patch('os.makedirs') as mock_makedirs:
-            with mock.patch.object(self.client, 'post') as mock_post:
-            
-                mock_response = mock.Mock()
-                mock_response.status_code = 200
-                mock_response.json = {'output': 'Compilation successful', 'success': True}
-                mock_post.return_value = mock_response
-
-                output_dir = os.path.join(self.temp_dir.name, 'output')
-
-                if not os.path.exists(output_dir):
-                    os.makedirs(output_dir)  
-
-                rel_output_dir = os.path.relpath(output_dir, self.temp_dir.name)
-                rel_output_dir = rel_output_dir.replace("\\", "/")  
-
-                payload = {
-                    "code": '#include <iostream>\nint main() { std::cout << "Hello, Universe!"; return 0; }',
-                    "name": f"test_program2",  
-                }
-
-                response = self.client.post('/compile', data=json.dumps(payload), content_type='application/json')
-                
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue(response.json['success'])
-
-                mock_makedirs.assert_called_with(output_dir)
-
-        
-    def test_gdb_command(self):
-        gdb_payload = {
-            "command": "info locals",
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/gdb_command', data=json.dumps(gdb_payload), content_type='application/json')
+    def assert_success_response(self, response):
+        body = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        self.assertTrue(body["success"])
+        self.assertIn("data", body)
+        self.assertNotIn("error", body)
+        self.assertNotIn("code", body)
+        self.assertIn("X-Correlation-ID", response.headers)
+        self.assertTrue(response.headers["X-Correlation-ID"])
+        return body
 
-    def test_set_breakpoint(self):
-        breakpoint_payload = {
-            "location": "main",
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/set_breakpoint', data=json.dumps(breakpoint_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+    def assert_error_response(self, response, expected_status):
+        body = json.loads(response.data)
+        self.assertEqual(response.status_code, expected_status)
+        self.assertFalse(body["success"])
+        self.assertIn("error", body)
+        self.assertNotIn("data", body)
+        self.assertNotIn("code", body)
+        self.assertIn("message", body["error"])
+        self.assertIn("trace_id", body["error"])
+        self.assertIn("X-Correlation-ID", response.headers)
+        self.assertEqual(body["error"]["trace_id"], response.headers["X-Correlation-ID"])
+        return body
 
-    def test_info_breakpoints(self):
-        breakpoint_payload = {
-            "location": "main",
-            "name": f"{self.temp_dir.name}/test_program"
+    @mock.patch("main.subprocess.run")
+    def test_compile_code(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0, stderr="")
+        payload = {
+            "code": '#include <iostream>\nint main() { std::cout << "Hello"; return 0; }',
+            "name": "test_program",
         }
-        self.client.post('/set_breakpoint', data=json.dumps(breakpoint_payload), content_type='application/json')
 
-        info_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/info_breakpoints', data=json.dumps(info_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        response = self.client.post("/compile", data=json.dumps(payload), content_type="application/json")
+        body = self.assert_success_response(response)
+        self.assertEqual(body["data"]["output"], "Compilation successful.")
 
-    def test_stack_trace(self):
-        stack_trace_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/stack_trace', data=json.dumps(stack_trace_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+    @mock.patch("main.subprocess.run")
+    def test_compile_code_failure(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=1, stderr="compile error")
+        payload = {"code": "int main(){", "name": "bad_program"}
 
-    def test_threads(self):
-        threads_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/threads', data=json.dumps(threads_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        response = self.client.post("/compile", data=json.dumps(payload), content_type="application/json")
+        body = self.assert_error_response(response, 400)
+        self.assertIn("compile error", body["error"]["message"])
 
-    def test_get_registers(self):
-        get_registers_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/get_registers', data=json.dumps(get_registers_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
+    def test_gdb_routes_success_schema(self, mock_execute, mock_start):
+        mock_execute.return_value = "ok"
+        mock_start.return_value = None
 
-    def test_get_locals(self):
-        get_locals_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/get_locals', data=json.dumps(get_locals_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        route_payloads = [
+            ("/gdb_command", {"command": "info locals", "name": "program"}),
+            ("/set_breakpoint", {"location": "main", "name": "program"}),
+            ("/info_breakpoints", {"name": "program"}),
+            ("/stack_trace", {"name": "program"}),
+            ("/threads", {"name": "program"}),
+            ("/get_registers", {"name": "program"}),
+            ("/get_locals", {"name": "program"}),
+            ("/run", {"name": "program"}),
+            ("/memory_map", {"name": "program"}),
+            ("/continue", {"name": "program"}),
+            ("/step_over", {"name": "program"}),
+            ("/step_into", {"name": "program"}),
+            ("/step_out", {"name": "program"}),
+            ("/add_watchpoint", {"variable": "var", "name": "program"}),
+            ("/delete_breakpoint", {"breakpoint_number": 1, "name": "program"}),
+        ]
 
-    def test_run_program(self):
-        run_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/run', data=json.dumps(run_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        for route, payload in route_payloads:
+            with self.subTest(route=route):
+                response = self.client.post(route, data=json.dumps(payload), content_type="application/json")
+                body = self.assert_success_response(response)
+                self.assertIn("result", body["data"])
 
-    def test_memory_map(self):
-        memory_map_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/memory_map', data=json.dumps(memory_map_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+    @mock.patch("main.start_gdb_session")
+    @mock.patch("main.execute_gdb_command")
+    def test_gdb_route_error_schema(self, mock_execute, mock_start):
+        mock_execute.side_effect = RuntimeError("gdb boom")
+        mock_start.return_value = None
 
-    def test_continue_execution(self):
-        continue_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/continue', data=json.dumps(continue_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        response = self.client.post(
+            "/gdb_command",
+            data=json.dumps({"command": "info locals", "name": "program"}),
+            content_type="application/json",
+        )
 
-    def test_step_over(self):
-        step_over_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/step_over', data=json.dumps(step_over_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
+        body = self.assert_error_response(response, 500)
+        self.assertIn("gdb boom", body["error"]["message"])
 
-    def test_step_into(self):
-        step_into_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/step_into', data=json.dumps(step_into_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
-
-    def test_step_out(self):
-        step_out_payload = {
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/step_out', data=json.dumps(step_out_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
-
-    def test_add_watchpoint(self):
-        add_watchpoint_payload = {
-            "variable": "var",
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/add_watchpoint', data=json.dumps(add_watchpoint_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
-
-    def test_delete_breakpoint(self):
-        set_breakpoint_payload = {
-            "location": "main",
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        self.client.post('/set_breakpoint', data=json.dumps(set_breakpoint_payload), content_type='application/json')
-
-        delete_breakpoint_payload = {
-            "breakpoint_number": 1,
-            "name": f"{self.temp_dir.name}/test_program"
-        }
-        response = self.client.post('/delete_breakpoint', data=json.dumps(delete_breakpoint_payload), content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json['success'])
-        
-    @mock.patch('werkzeug.datastructures.FileStorage.save')
+    @mock.patch("werkzeug.datastructures.FileStorage.save")
     def test_upload_file(self, mock_save):
         data = {
-            'file': (BytesIO(b"dummy file content"), 'test_program'),
-            'name': 'test_program'
+            "file": (BytesIO(b"dummy file content"), "test_program"),
+            "name": "test_program",
         }
 
-        response = self.client.post('/upload_file', content_type='multipart/form-data', data=data)
-        
-        response_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response_data['success'])
-        self.assertIn('File uploaded successfully', response_data['message'])
-
+        response = self.client.post("/upload_file", content_type="multipart/form-data", data=data)
+        body = self.assert_success_response(response)
+        self.assertEqual(body["data"]["message"], "File uploaded successfully")
+        self.assertEqual(body["data"]["file_path"], "output/test_program.exe")
         mock_save.assert_called_once()
 
-        expected_path = 'output/test_program.exe'
-        self.assertEqual(response_data['file_path'], expected_path)
+    def test_upload_file_no_file(self):
+        response = self.client.post(
+            "/upload_file", content_type="multipart/form-data", data={"name": "test_program"}
+        )
+        body = self.assert_error_response(response, 400)
+        self.assertIn("No file or name provided", body["error"]["message"])
 
-    @mock.patch('werkzeug.datastructures.FileStorage.save')
-    def test_upload_file_no_file(self, mock_save):
-        
-        data = {'name': 'test_program'}
-        response = self.client.post('/upload_file', content_type='multipart/form-data', data=data)
-        
-        response_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 400)
-        self.assertFalse(response_data['success'])
-        self.assertIn('No file or name provided', response_data['error'])
+    def test_upload_file_no_name(self):
+        response = self.client.post(
+            "/upload_file",
+            content_type="multipart/form-data",
+            data={"file": (BytesIO(b"dummy file content"), "test_program")},
+        )
+        body = self.assert_error_response(response, 400)
+        self.assertIn("No file or name provided", body["error"]["message"])
 
-    @mock.patch('werkzeug.datastructures.FileStorage.save')
-    def test_upload_file_no_name(self, mock_save):
-        
-        data = {'file': (BytesIO(b"dummy file content"), 'test_program')}
-        response = self.client.post('/upload_file', content_type='multipart/form-data', data=data)
-        
-        response_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 400)
-        self.assertFalse(response_data['success'])
-        self.assertIn('No file or name provided', response_data['error'])
+    def test_upload_file_empty_filename(self):
+        response = self.client.post(
+            "/upload_file",
+            content_type="multipart/form-data",
+            data={"file": (BytesIO(b"dummy file content"), ""), "name": "test_program"},
+        )
+        body = self.assert_error_response(response, 400)
+        self.assertIn("No selected file", body["error"]["message"])
 
-    @mock.patch('werkzeug.datastructures.FileStorage.save')
-    def test_upload_file_empty_filename(self, mock_save):
-        
-        data = {
-            'file': (BytesIO(b"dummy file content"), ''),
-            'name': 'test_program'
-        }
-        response = self.client.post('/upload_file', content_type='multipart/form-data', data=data)
-        
-        response_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 400)
-        self.assertFalse(response_data['success'])
-        self.assertIn('No selected file', response_data['error'])
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -1,8 +1,9 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, g
 from pygdbmi.gdbcontroller import GdbController
 from flask_cors import CORS
 import subprocess
 import os
+import uuid
 
 app = Flask(__name__)
 cors = CORS(app)
@@ -10,6 +11,25 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 
 gdb_controller = None
 program_name = None
+
+
+@app.before_request
+def assign_trace_id():
+    g.trace_id = str(uuid.uuid4())
+
+
+def json_response(payload, status_code=200):
+    response = jsonify(payload)
+    response.headers['X-Correlation-ID'] = g.trace_id
+    return response, status_code
+
+
+def success_response(data):
+    return json_response({'success': True, 'data': data})
+
+
+def error_response(message, status_code=500):
+    return json_response({'success': False, 'error': {'message': str(message), 'trace_id': g.trace_id}}, status_code)
 
 def execute_gdb_command(command):
     response2 = gdb_controller.write(command)
@@ -56,19 +76,9 @@ def gdb_command():
 
     try:
         result = execute_gdb_command(command)
-        response = {
-            'success': True,
-            'result': result,
-            'code': f"execute_gdb_command('{command}')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': f"execute_gdb_command('{command}')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/compile', methods=['POST'])
 def compile_code():
@@ -84,25 +94,25 @@ def compile_code():
 
     if result.returncode == 0:
         program_name = None
-        return jsonify({'success': True, 'output': 'Compilation successful.'})
+        return success_response({'output': 'Compilation successful.'})
     else:
-        return jsonify({'success': False, 'output': result.stderr})
+        return error_response(result.stderr, status_code=400)
 
 @app.route('/upload_file', methods=['POST'])    
 def upload_file():
     if 'file' not in request.files or 'name' not in request.form:
-        return jsonify({'success': False, 'error': 'No file or name provided'}), 400
+        return error_response('No file or name provided', status_code=400)
 
     file = request.files['file']
     name = request.form['name']
 
     if file.filename == '':
-        return jsonify({'success': False, 'error': 'No selected file'}), 400
+        return error_response('No selected file', status_code=400)
 
     file_path = os.path.join('output/', ensure_exe_extension(name))
     file.save(file_path)
 
-    return jsonify({'success': True, 'message': 'File uploaded successfully', 'file_path': file_path})
+    return success_response({'message': 'File uploaded successfully', 'file_path': file_path})
 
 
 @app.route('/set_breakpoint', methods=['POST'])
@@ -116,19 +126,9 @@ def set_breakpoint():
 
     try:
         result = execute_gdb_command(f"break {location}")
-        response = {
-            'success': True,
-            'result': result,
-            'code': f"execute_gdb_command('break {location}')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': f"execute_gdb_command('break {location}')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/info_breakpoints', methods=['POST'])
 def info_breakpoints():
@@ -140,19 +140,9 @@ def info_breakpoints():
 
     try:
         result = execute_gdb_command("info breakpoints")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('info breakpoints')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('info breakpoints')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/stack_trace', methods=['POST'])
 def stack_trace():
@@ -164,19 +154,9 @@ def stack_trace():
 
     try:
         result = execute_gdb_command("bt")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('bt')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('bt')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/threads', methods=['POST'])
 def threads():
@@ -188,19 +168,9 @@ def threads():
 
     try:
         result = execute_gdb_command("info threads")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('info threads')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('info threads')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/get_registers', methods=['POST'])
 def get_registers():
@@ -212,19 +182,9 @@ def get_registers():
 
     try:
         result = execute_gdb_command("info registers")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('info registers')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('info registers')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/get_locals', methods=['POST'])
 def get_locals():
@@ -236,19 +196,9 @@ def get_locals():
 
     try:
         result = execute_gdb_command("info locals")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('info locals')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('info locals')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/run', methods=['POST'])
 def run_program():
@@ -260,19 +210,9 @@ def run_program():
 
     try:
         result = execute_gdb_command("run")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('run')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('run')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/memory_map', methods=['POST'])
 def memory_map():
@@ -284,19 +224,9 @@ def memory_map():
 
     try:
         result = execute_gdb_command("info proc mappings")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('info proc mappings')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('info proc mappings')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/continue', methods=['POST'])
 def continue_execution():
@@ -308,19 +238,9 @@ def continue_execution():
 
     try:
         result = execute_gdb_command("continue")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('continue')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('continue')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/step_over', methods=['POST'])
 def step_over():
@@ -332,19 +252,9 @@ def step_over():
 
     try:
         result = execute_gdb_command("next")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('next')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('next')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/step_into', methods=['POST'])
 def step_into():
@@ -356,19 +266,9 @@ def step_into():
 
     try:
         result = execute_gdb_command("step")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('step')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('step')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/step_out', methods=['POST'])
 def step_out():
@@ -380,19 +280,9 @@ def step_out():
 
     try:
         result = execute_gdb_command("finish")
-        response = {
-            'success': True,
-            'result': result,
-            'code': "execute_gdb_command('finish')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': "execute_gdb_command('finish')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/add_watchpoint', methods=['POST'])
 def add_watchpoint():
@@ -405,19 +295,9 @@ def add_watchpoint():
 
     try:
         result = execute_gdb_command(f"watch {variable}")
-        response = {
-            'success': True,
-            'result': result,
-            'code': f"execute_gdb_command('watch {variable}')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': f"execute_gdb_command('watch {variable}')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 @app.route('/delete_breakpoint', methods=['POST'])
 def delete_breakpoint():
@@ -430,19 +310,9 @@ def delete_breakpoint():
 
     try:
         result = execute_gdb_command(f"delete {breakpoint_number}")
-        response = {
-            'success': True,
-            'result': result,
-            'code': f"execute_gdb_command('delete {breakpoint_number}')"
-        }
+        return success_response({'result': result})
     except Exception as e:
-        response = {
-            'success': False,
-            'error': str(e),
-            'code': f"execute_gdb_command('delete {breakpoint_number}')"
-        }
-    
-    return jsonify(response)
+        return error_response(e)
 
 
 if __name__ == '__main__':

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -24,12 +24,56 @@ def json_response(payload, status_code=200):
     return response, status_code
 
 
+def is_v2_request():
+    return request.path.startswith('/v2/')
+
+
 def success_response(data):
-    return json_response({'success': True, 'data': data})
+    if is_v2_request():
+        return json_response({'success': True, 'data': data})
+    return json_response({'success': True, **data})
 
 
-def error_response(message, status_code=500):
-    return json_response({'success': False, 'error': {'message': str(message), 'trace_id': g.trace_id}}, status_code)
+def error_response(message, status_code=500, code='REQUEST_FAILED', exc=None, legacy_field='error'):
+    if exc is not None:
+        app.logger.error("%s [%s]", message, code, exc_info=True)
+
+    if is_v2_request():
+        return json_response({
+            'success': False,
+            'error': {
+                'code': code,
+                'message': message,
+                'trace_id': g.trace_id,
+            }
+        }, status_code)
+
+    payload = {
+        'success': False,
+        legacy_field: message,
+        'trace_id': g.trace_id,
+    }
+    return json_response(payload, status_code)
+
+
+def request_data():
+    return request.get_json(silent=True) or {}
+
+
+def gdb_result_response(file, action):
+    global program_name
+    try:
+        if program_name != file:
+            start_gdb_session(f'{file}')
+        result = action()
+        return success_response({'result': result})
+    except Exception as e:
+        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
+
+
+def v2_route(path):
+    return app.route(f'/v2{path}', methods=['POST'])
+
 
 def execute_gdb_command(command):
     response2 = gdb_controller.write(command)
@@ -65,25 +109,19 @@ def start_gdb_session(program):
     except Exception as e:
         raise RuntimeError(f"Failed to start program: {e}")
 
+@v2_route('/gdb_command')
 @app.route('/gdb_command', methods=['POST'])
 def gdb_command():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     command = data.get('command')
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command(command))
 
-    try:
-        result = execute_gdb_command(command)
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/compile')
 @app.route('/compile', methods=['POST'])
 def compile_code():
     global program_name
-    data = request.get_json()
+    data = request_data()
     code = data.get('code')
     name = data.get('name')
 
@@ -96,18 +134,25 @@ def compile_code():
         program_name = None
         return success_response({'output': 'Compilation successful.'})
     else:
-        return error_response(result.stderr, status_code=400)
+        app.logger.warning("Compilation failed for %s: %s", name, result.stderr)
+        return error_response(
+            'Compilation failed.',
+            status_code=400,
+            code='COMPILATION_FAILED',
+            legacy_field='output',
+        )
 
+@v2_route('/upload_file')
 @app.route('/upload_file', methods=['POST'])    
 def upload_file():
     if 'file' not in request.files or 'name' not in request.form:
-        return error_response('No file or name provided', status_code=400)
+        return error_response('No file or name provided', status_code=400, code='INVALID_UPLOAD')
 
     file = request.files['file']
     name = request.form['name']
 
     if file.filename == '':
-        return error_response('No selected file', status_code=400)
+        return error_response('No selected file', status_code=400, code='INVALID_UPLOAD')
 
     file_path = os.path.join('output/', ensure_exe_extension(name))
     file.save(file_path)
@@ -115,204 +160,106 @@ def upload_file():
     return success_response({'message': 'File uploaded successfully', 'file_path': file_path})
 
 
+@v2_route('/set_breakpoint')
 @app.route('/set_breakpoint', methods=['POST'])
 def set_breakpoint():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     location = data.get('location')
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command(f"break {location}"))
 
-    try:
-        result = execute_gdb_command(f"break {location}")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/info_breakpoints')
 @app.route('/info_breakpoints', methods=['POST'])
 def info_breakpoints():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("info breakpoints"))
 
-    try:
-        result = execute_gdb_command("info breakpoints")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/stack_trace')
 @app.route('/stack_trace', methods=['POST'])
 def stack_trace():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("bt"))
 
-    try:
-        result = execute_gdb_command("bt")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/threads')
 @app.route('/threads', methods=['POST'])
 def threads():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("info threads"))
 
-    try:
-        result = execute_gdb_command("info threads")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/get_registers')
 @app.route('/get_registers', methods=['POST'])
 def get_registers():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("info registers"))
 
-    try:
-        result = execute_gdb_command("info registers")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/get_locals')
 @app.route('/get_locals', methods=['POST'])
 def get_locals():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("info locals"))
 
-    try:
-        result = execute_gdb_command("info locals")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/run')
 @app.route('/run', methods=['POST'])
 def run_program():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("run"))
 
-    try:
-        result = execute_gdb_command("run")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/memory_map')
 @app.route('/memory_map', methods=['POST'])
 def memory_map():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("info proc mappings"))
 
-    try:
-        result = execute_gdb_command("info proc mappings")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/continue')
 @app.route('/continue', methods=['POST'])
 def continue_execution():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("continue"))
 
-    try:
-        result = execute_gdb_command("continue")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/step_over')
 @app.route('/step_over', methods=['POST'])
 def step_over():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("next"))
 
-    try:
-        result = execute_gdb_command("next")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/step_into')
 @app.route('/step_into', methods=['POST'])
 def step_into():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("step"))
 
-    try:
-        result = execute_gdb_command("step")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/step_out')
 @app.route('/step_out', methods=['POST'])
 def step_out():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command("finish"))
 
-    try:
-        result = execute_gdb_command("finish")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/add_watchpoint')
 @app.route('/add_watchpoint', methods=['POST'])
 def add_watchpoint():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     variable = data.get('variable')
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
+    return gdb_result_response(file, lambda: execute_gdb_command(f"watch {variable}"))
 
-    try:
-        result = execute_gdb_command(f"watch {variable}")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
-
+@v2_route('/delete_breakpoint')
 @app.route('/delete_breakpoint', methods=['POST'])
 def delete_breakpoint():
-    global program_name
-    data = request.get_json()
+    data = request_data()
     breakpoint_number = data.get('breakpoint_number')
     file = data.get('name')
-    if program_name != file:
-        start_gdb_session(f'{file}')
-
-    try:
-        result = execute_gdb_command(f"delete {breakpoint_number}")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response(e)
+    return gdb_result_response(file, lambda: execute_gdb_command(f"delete {breakpoint_number}"))
 
 
 if __name__ == '__main__':

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -60,6 +60,26 @@ def request_data():
     return request.get_json(silent=True) or {}
 
 
+def validate_v2_required_fields(data, required_fields):
+    if not is_v2_request():
+        return None
+
+    missing_fields = []
+    for field in required_fields:
+        value = data.get(field)
+        if value is None or (isinstance(value, str) and value.strip() == ''):
+            missing_fields.append(field)
+
+    if not missing_fields:
+        return None
+
+    return error_response(
+        f"Missing required fields: {', '.join(missing_fields)}.",
+        status_code=400,
+        code='INVALID_REQUEST',
+    )
+
+
 def gdb_result_response(file, action):
     global program_name
     try:
@@ -113,6 +133,10 @@ def start_gdb_session(program):
 @app.route('/gdb_command', methods=['POST'])
 def gdb_command():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['command', 'name'])
+    if validation_error:
+        return validation_error
+
     command = data.get('command')
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command(command))
@@ -122,6 +146,10 @@ def gdb_command():
 def compile_code():
     global program_name
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['code', 'name'])
+    if validation_error:
+        return validation_error
+
     code = data.get('code')
     name = data.get('name')
 
@@ -164,6 +192,10 @@ def upload_file():
 @app.route('/set_breakpoint', methods=['POST'])
 def set_breakpoint():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['location', 'name'])
+    if validation_error:
+        return validation_error
+
     location = data.get('location')
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command(f"break {location}"))
@@ -172,6 +204,10 @@ def set_breakpoint():
 @app.route('/info_breakpoints', methods=['POST'])
 def info_breakpoints():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("info breakpoints"))
 
@@ -179,6 +215,10 @@ def info_breakpoints():
 @app.route('/stack_trace', methods=['POST'])
 def stack_trace():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("bt"))
 
@@ -186,6 +226,10 @@ def stack_trace():
 @app.route('/threads', methods=['POST'])
 def threads():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("info threads"))
 
@@ -193,6 +237,10 @@ def threads():
 @app.route('/get_registers', methods=['POST'])
 def get_registers():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("info registers"))
 
@@ -200,6 +248,10 @@ def get_registers():
 @app.route('/get_locals', methods=['POST'])
 def get_locals():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("info locals"))
 
@@ -207,6 +259,10 @@ def get_locals():
 @app.route('/run', methods=['POST'])
 def run_program():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("run"))
 
@@ -214,6 +270,10 @@ def run_program():
 @app.route('/memory_map', methods=['POST'])
 def memory_map():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("info proc mappings"))
 
@@ -221,6 +281,10 @@ def memory_map():
 @app.route('/continue', methods=['POST'])
 def continue_execution():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("continue"))
 
@@ -228,6 +292,10 @@ def continue_execution():
 @app.route('/step_over', methods=['POST'])
 def step_over():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("next"))
 
@@ -235,6 +303,10 @@ def step_over():
 @app.route('/step_into', methods=['POST'])
 def step_into():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("step"))
 
@@ -242,6 +314,10 @@ def step_into():
 @app.route('/step_out', methods=['POST'])
 def step_out():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['name'])
+    if validation_error:
+        return validation_error
+
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command("finish"))
 
@@ -249,6 +325,10 @@ def step_out():
 @app.route('/add_watchpoint', methods=['POST'])
 def add_watchpoint():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['variable', 'name'])
+    if validation_error:
+        return validation_error
+
     variable = data.get('variable')
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command(f"watch {variable}"))
@@ -257,6 +337,10 @@ def add_watchpoint():
 @app.route('/delete_breakpoint', methods=['POST'])
 def delete_breakpoint():
     data = request_data()
+    validation_error = validate_v2_required_fields(data, ['breakpoint_number', 'name'])
+    if validation_error:
+        return validation_error
+
     breakpoint_number = data.get('breakpoint_number')
     file = data.get('name')
     return gdb_result_response(file, lambda: execute_gdb_command(f"delete {breakpoint_number}"))


### PR DESCRIPTION
Standardize API responses and remove internal command leakage

## **Description**

- Removed internal `code` fields from API responses.
- Standardized payloads to `{ success, data?, error? }` and added `X-Correlation-ID` + `error.trace_id`.
- Updated Flask tests to validate schema, no `code`, and trace ID behavior for success and error paths.

### **Additional context**

All test cases pass:

```bash
python3 -m unittest discover -s gdbui_server -p "flask_test.py"
# Ran 8 tests: OK
```