### PR TITLE
refactor: address PR #131 review comments — fix info locals + DRY up 11 GDB routes

### DIFF
--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -155,14 +155,14 @@ def register_gdb_route(route, command, required_fields=None):
         session_id, error = get_session_id(data)
         if error:
             return error
-        file = data.get('name')
+        program = data.get('name')
 
         validation_error = validate_v2_required_fields(data, required_fields)
         if validation_error:
             return validation_error
 
         try:
-            session_manager.ensure_program(session_id, file)
+            session_manager.ensure_program(session_id, program)
             result = session_manager.execute(session_id, command)
             return success_response({'result': result})
         except Exception as e:

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -132,6 +132,48 @@ def get_session_id(data):
 
 
 # ---------------------------------------------------------------------------
+# GDB route registration helper (reduces boilerplate for fixed-command routes)
+# ---------------------------------------------------------------------------
+
+def register_gdb_route(route, command, required_fields=None):
+    """Register a GDB command route with both /v2/... and /... paths.
+
+    Handles repeated boilerplate: JSON body parsing, session validation,
+    required-field validation, GDB command execution, and error wrapping.
+
+    Args:
+        route: The route path (e.g. '/stack_trace').
+        command: The GDB command string to execute.
+        required_fields: List of required JSON body fields (default ['name']).
+    """
+    required_fields = required_fields or ['name']
+
+    def handler():
+        data, err = get_request_data()
+        if err:
+            return err
+        session_id, error = get_session_id(data)
+        if error:
+            return error
+        file = data.get('name')
+
+        validation_error = validate_v2_required_fields(data, required_fields)
+        if validation_error:
+            return validation_error
+
+        try:
+            session_manager.ensure_program(session_id, file)
+            result = session_manager.execute(session_id, command)
+            return success_response({'result': result})
+        except Exception as e:
+            return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
+
+    app.route(route, methods=['POST'])(handler)
+    app.route(f'/v2{route}', methods=['POST'])(handler)
+    return handler
+
+
+# ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
@@ -365,257 +407,17 @@ def set_breakpoint():
         return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
 
 
-@v2_route('/info_breakpoints')
-@app.route('/info_breakpoints', methods=['POST'])
-def info_breakpoints():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "info breakpoints")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/stack_trace')
-@app.route('/stack_trace', methods=['POST'])
-def stack_trace():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "bt")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/threads')
-@app.route('/threads', methods=['POST'])
-def threads():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "info threads")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/get_registers')
-@app.route('/get_registers', methods=['POST'])
-def get_registers():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "info registers")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/get_locals')
-@app.route('/get_locals', methods=['POST'])
-def get_locals():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "info functions")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/run')
-@app.route('/run', methods=['POST'])
-def run_program():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "run")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/memory_map')
-@app.route('/memory_map', methods=['POST'])
-def memory_map():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "info proc mappings")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/continue')
-@app.route('/continue', methods=['POST'])
-def continue_execution():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "continue")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/step_over')
-@app.route('/step_over', methods=['POST'])
-def step_over():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "next")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/step_into')
-@app.route('/step_into', methods=['POST'])
-def step_into():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "step")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
-
-
-@v2_route('/step_out')
-@app.route('/step_out', methods=['POST'])
-def step_out():
-    data, err = get_request_data()
-    if err:
-        return err
-    session_id, error = get_session_id(data)
-    if error:
-        return error
-    file = data.get('name')
-
-    validation_error = validate_v2_required_fields(data, ['name'])
-    if validation_error:
-        return validation_error
-
-    try:
-        session_manager.ensure_program(session_id, file)
-        result = session_manager.execute(session_id, "finish")
-        return success_response({'result': result})
-    except Exception as e:
-        return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
+register_gdb_route('/info_breakpoints', 'info breakpoints')
+register_gdb_route('/stack_trace', 'bt')
+register_gdb_route('/threads', 'info threads')
+register_gdb_route('/get_registers', 'info registers')
+register_gdb_route('/get_locals', 'info locals')
+register_gdb_route('/run', 'run')
+register_gdb_route('/memory_map', 'info proc mappings')
+register_gdb_route('/continue', 'continue')
+register_gdb_route('/step_over', 'next')
+register_gdb_route('/step_into', 'step')
+register_gdb_route('/step_out', 'finish')
 
 
 @v2_route('/add_watchpoint')

--- a/gdbui_server/main.py
+++ b/gdbui_server/main.py
@@ -146,7 +146,7 @@ def register_gdb_route(route, command, required_fields=None):
         command: The GDB command string to execute.
         required_fields: List of required JSON body fields (default ['name']).
     """
-    required_fields = required_fields or ['name']
+    required_fields = required_fields if required_fields is not None else ['name']
 
     def handler():
         data, err = get_request_data()
@@ -168,6 +168,9 @@ def register_gdb_route(route, command, required_fields=None):
         except Exception as e:
             return error_response('GDB command failed.', code='GDB_COMMAND_FAILED', exc=e)
 
+    # Give each handler a unique name so Flask endpoints don't collide
+    endpoint = route.strip('/').replace('/', '_') or 'root'
+    handler.__name__ = f"gdb_{endpoint}"
     app.route(route, methods=['POST'])(handler)
     app.route(f'/v2{route}', methods=['POST'])(handler)
     return handler


### PR DESCRIPTION
This PR addresses the two review comments left by @Shubh942 on #131:

1. Bug fix: /get_locals was calling `info functions` instead of `info locals` — now returns actual local variables as intended
2. Refactor: Extracted 11 identical GDB command routes into a `register_gdb_route()` helper, reducing 251 lines of boilerplate to 53 lines (~79% reduction)

Routes refactored: info_breakpoints, stack_trace, threads, get_registers, get_locals, run, memory_map, continue, step_over, step_into, step_out

Routes kept as-is (different patterns): gdb_command, compile, upload_file, create_session, end_session, set_breakpoint, add_watchpoint, delete_breakpoint

The helper preserves the existing dual-route registration (/route + /v2/route) and accepts optional required_fields for routes with custom validation.

All 48 tests passing (19 backend + 29 frontend). No breaking changes to API response format or error handling.