### PR TITLE
feat: add Docker sandbox infrastructure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,21 @@ services:
       context: ./gdbui_server
     volumes:
       - ./gdbui_server:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - GDBUI_DOCKER=false
     ports:
       - "10000:10000"
     expose:
       - 10000
+
+  sandbox-image:
+    build:
+      dockerfile: sandbox.Dockerfile
+      context: ./gdbui_server/docker
+    image: gdbui-sandbox:latest
+    profiles:
+      - build
 
   webapp:
     build:

--- a/gdbui_server/docker/sandbox.Dockerfile
+++ b/gdbui_server/docker/sandbox.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gdb \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+CMD ["sleep", "infinity"]

--- a/gdbui_server/sandbox.py
+++ b/gdbui_server/sandbox.py
@@ -1,0 +1,96 @@
+"""Per-session Docker container management for GDB sandboxing.
+
+Each session gets a dedicated container with read-only rootfs and no network.
+GDB and g++ are invoked via ``docker exec``. The session's output directory
+is bind-mounted at /workspace so compiled binaries are immediately available.
+
+Usage::
+
+    from sandbox import start_container, stop_container
+
+    name = start_container(session_id, output_dir)
+    if name:
+        GdbController(command=["docker", "exec", "-i", name, "gdb", "--interpreter=mi2"])
+    stop_container(session_id)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+SANDBOX_ENABLED = os.environ.get("GDBUI_DOCKER", "").lower() in ("1", "true", "yes")
+SANDBOX_IMAGE = os.environ.get("GDBUI_SANDBOX_IMAGE", "gdbui-sandbox:latest")
+CONTAINER_PREFIX = "gdbui-"
+
+
+def _container_name(session_id: str) -> str:
+    """Deterministic container name derived from session id."""
+    return f"{CONTAINER_PREFIX}{session_id[:8]}"
+
+
+def start_container(session_id: str, output_dir: str) -> str | None:
+    """Start a sandbox container for *session_id*.
+
+    The container stays alive (``sleep infinity``) until explicitly stopped.
+    *output_dir* is bind-mounted at ``/workspace`` inside the container.
+
+    Returns the container name, or ``None`` if sandboxing is disabled.
+    """
+    if not SANDBOX_ENABLED:
+        return None
+
+    name = _container_name(session_id)
+    abs_output = os.path.abspath(output_dir)
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                name,
+                "-v",
+                f"{abs_output}:/workspace",
+                "--network",
+                "none",
+                "--read-only",
+                "--tmpfs",
+                "/tmp:rw,noexec,nosuid,size=64m",
+                SANDBOX_IMAGE,
+                "sleep",
+                "86400",
+            ],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+        logger.info("Sandbox started: %s (%s)", name, session_id)
+        return name
+    except Exception:
+        logger.exception("Failed to start sandbox for session %s", session_id)
+        return None
+
+
+def stop_container(session_id: str) -> None:
+    """Stop and remove the sandbox container for *session_id*.
+
+    Safe to call even if the container was never started or already removed.
+    """
+    if not SANDBOX_ENABLED:
+        return
+
+    name = _container_name(session_id)
+    try:
+        subprocess.run(
+            ["docker", "rm", "-f", name],
+            capture_output=True,
+            timeout=15,
+        )
+        logger.info("Sandbox stopped: %s", name)
+    except Exception:
+        logger.exception("Failed to stop sandbox container %s", name)

--- a/gdbui_server/tests/test_sandbox.py
+++ b/gdbui_server/tests/test_sandbox.py
@@ -1,0 +1,96 @@
+"""Tests for the sandbox module."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestSandboxDisabled(unittest.TestCase):
+    """When GDBUI_DOCKER is not set, start/stop are no-ops."""
+
+    def setUp(self):
+        # Ensure env var is not set
+        os.environ.pop("GDBUI_DOCKER", None)
+        # Force reimport with clean env
+        if "sandbox" in sys.modules:
+            del sys.modules["sandbox"]
+
+    def test_start_returns_none_when_disabled(self):
+        from sandbox import start_container
+
+        self.assertIsNone(start_container("any-sid", "/tmp"))
+
+    def test_stop_does_nothing_when_disabled(self):
+        from sandbox import stop_container
+
+        try:
+            stop_container("any-sid")
+        except Exception:
+            self.fail("stop_container raised unexpectedly")
+
+    def test_container_name_ignores_env(self):
+        from sandbox import _container_name
+
+        self.assertEqual(_container_name("a1b2c3d4"), "gdbui-a1b2c3d4")
+        self.assertEqual(_container_name("550e8400-e29b-41d4-a716"), "gdbui-550e8400")
+
+
+class TestSandboxEnabled(unittest.TestCase):
+    """When GDBUI_DOCKER=true, start/stop shell out to docker CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["GDBUI_DOCKER"] = "true"
+        if "sandbox" in sys.modules:
+            del sys.modules["sandbox"]
+        import sandbox as sb
+
+        cls.sb = sb
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("GDBUI_DOCKER", None)
+
+    @patch("sandbox.subprocess.run")
+    def test_start_runs_docker(self, mock_run):
+        name = self.sb.start_container("550e8400-e29b-41d4-a716", "output/sid")
+        self.assertEqual(name, "gdbui-550e8400")
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("docker", call_args)
+        self.assertIn("run", call_args)
+        self.assertIn("gdbui-550e8400", call_args)
+        self.assertIn("--read-only", call_args)
+        self.assertIn("--network", call_args)
+        self.assertIn("none", call_args)
+
+    @patch("sandbox.subprocess.run")
+    def test_start_mounts_output_dir(self, mock_run):
+        self.sb.start_container("sid12345", "output/sid12345")
+        call_args = mock_run.call_args[0][0]
+        vol_idx = call_args.index("-v") + 1
+        self.assertIn("output/sid12345:/workspace", call_args[vol_idx])
+
+    @patch("sandbox.subprocess.run")
+    def test_stop_runs_docker_rm(self, mock_run):
+        self.sb.stop_container("550e8400-e29b-41d4-a716")
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("docker", call_args)
+        self.assertIn("rm", call_args)
+
+    @patch("sandbox.subprocess.run")
+    def test_stop_silent_on_missing(self, mock_run):
+        mock_run.side_effect = Exception("container not found")
+        self.sb.stop_container("missing")
+
+    @patch("sandbox.subprocess.run")
+    def test_start_returns_none_on_failure(self, mock_run):
+        mock_run.side_effect = Exception("docker daemon not running")
+        result = self.sb.start_container("any", "/tmp")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Creates the infrastructure for per-session Docker sandbox isolation (Phase 3, PR 1/3). No behavioral change yet — the sandbox module exists but isn't wired into session lifecycle.

## Changes

- **`gdbui_server/docker/sandbox.Dockerfile`** — Sandbox container image (python:3.10-slim + gdb 16.3 + g++ 14.2.0)
- **`gdbui_server/sandbox.py`** — `start_container()`/\`stop_container()` helpers (~25 lines). Container flags: `--read-only`, `--network none`, `--tmpfs`. Session output dir bind-mounted at /workspace.
- **`gdbui_server/tests/test_sandbox.py`** — 8 tests (disabled mode + enabled mode with mocked docker CLI)
- **`docker-compose.yml`** — Docker socket mount, `GDBUI_DOCKER=false` env var (off by default), sandbox-image build service

## Verification

- 49/49 tests passing (41 existing + 8 new)
- Sandbox image built and verified: gdb --version (16.3), g++ --version (14.2.0)

## Build

```bash
docker compose --profile build build sandbox-image
```