### PR TITLE
feat: wire sandbox containers into session lifecycle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,21 @@ services:
       context: ./gdbui_server
     volumes:
       - ./gdbui_server:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - GDBUI_DOCKER=false
     ports:
       - "10000:10000"
     expose:
       - 10000
+
+  sandbox-image:
+    build:
+      dockerfile: sandbox.Dockerfile
+      context: ./gdbui_server/docker
+    image: gdbui-sandbox:latest
+    profiles:
+      - build
 
   webapp:
     build:

--- a/gdbui_server/docker/sandbox.Dockerfile
+++ b/gdbui_server/docker/sandbox.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gdb \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+CMD ["sleep", "infinity"]

--- a/gdbui_server/sandbox.py
+++ b/gdbui_server/sandbox.py
@@ -1,0 +1,96 @@
+"""Per-session Docker container management for GDB sandboxing.
+
+Each session gets a dedicated container with read-only rootfs and no network.
+GDB and g++ are invoked via ``docker exec``. The session's output directory
+is bind-mounted at /workspace so compiled binaries are immediately available.
+
+Usage::
+
+    from sandbox import start_container, stop_container
+
+    name = start_container(session_id, output_dir)
+    if name:
+        GdbController(command=["docker", "exec", "-i", name, "gdb", "--interpreter=mi2"])
+    stop_container(session_id)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+SANDBOX_ENABLED = os.environ.get("GDBUI_DOCKER", "").lower() in ("1", "true", "yes")
+SANDBOX_IMAGE = os.environ.get("GDBUI_SANDBOX_IMAGE", "gdbui-sandbox:latest")
+CONTAINER_PREFIX = "gdbui-"
+
+
+def _container_name(session_id: str) -> str:
+    """Deterministic container name derived from session id."""
+    return f"{CONTAINER_PREFIX}{session_id[:8]}"
+
+
+def start_container(session_id: str, output_dir: str) -> str | None:
+    """Start a sandbox container for *session_id*.
+
+    The container stays alive (``sleep infinity``) until explicitly stopped.
+    *output_dir* is bind-mounted at ``/workspace`` inside the container.
+
+    Returns the container name, or ``None`` if sandboxing is disabled.
+    """
+    if not SANDBOX_ENABLED:
+        return None
+
+    name = _container_name(session_id)
+    abs_output = os.path.abspath(output_dir)
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                name,
+                "-v",
+                f"{abs_output}:/workspace",
+                "--network",
+                "none",
+                "--read-only",
+                "--tmpfs",
+                "/tmp:rw,noexec,nosuid,size=64m",
+                SANDBOX_IMAGE,
+                "sleep",
+                "86400",
+            ],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+        logger.info("Sandbox started: %s (%s)", name, session_id)
+        return name
+    except Exception:
+        logger.exception("Failed to start sandbox for session %s", session_id)
+        return None
+
+
+def stop_container(session_id: str) -> None:
+    """Stop and remove the sandbox container for *session_id*.
+
+    Safe to call even if the container was never started or already removed.
+    """
+    if not SANDBOX_ENABLED:
+        return
+
+    name = _container_name(session_id)
+    try:
+        subprocess.run(
+            ["docker", "rm", "-f", name],
+            capture_output=True,
+            timeout=15,
+        )
+        logger.info("Sandbox stopped: %s", name)
+    except Exception:
+        logger.exception("Failed to stop sandbox container %s", name)

--- a/gdbui_server/session_manager.py
+++ b/gdbui_server/session_manager.py
@@ -10,6 +10,7 @@ import gevent
 from gevent.event import Event
 from pygdbmi.gdbcontroller import GdbController
 import pygdbmi.gdbmiparser as gdbmiparser
+from sandbox import SANDBOX_ENABLED, start_container, stop_container
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,7 @@ class SessionManager:
             except Exception as e:
                 logger.warning("Failed to exit controller for expired session %s: %s", session_id, e)
         if session:
+            stop_container(session_id)
             shutil.rmtree(os.path.join('output', session_id), ignore_errors=True)
             logger.info("Expired session cleaned up: %s", session_id)
 
@@ -267,6 +269,7 @@ class SessionManager:
                 session['controller'].exit()
             except Exception as e:
                 logger.warning("Failed to exit controller for session %s: %s", session_id, e)
+        stop_container(session_id)
         if session:
             shutil.rmtree(os.path.join('output', session_id), ignore_errors=True)
             logger.info("Session ended: %s", session_id)
@@ -305,14 +308,20 @@ class SessionManager:
                     old_controller.exit()
                 except Exception as e:
                     logger.warning("Failed to exit old controller for session %s: %s", session_id, e)
+                stop_container(session_id)
 
-            controller = GdbController()
+            container_name = start_container(session_id, session_output_dir) if SANDBOX_ENABLED else None
+            if SANDBOX_ENABLED and container_name is None:
+                raise RuntimeError("Sandbox container failed to start. Refusing to run unsandboxed.")
+            controller = GdbController(command=['docker', 'exec', '-i', container_name, 'gdb', '--interpreter=mi2']) if container_name else GdbController()
             try:
                 binary_name = safe_name.replace('.cpp', '').replace('.c', '').replace('.exe', '')
-                exe_path = os.path.join('output', session_id, ensure_exe_extension(binary_name))
+                binary_file = ensure_exe_extension(binary_name)
+                exe_path = os.path.join('output', session_id, binary_file)
                 if not os.path.exists(exe_path):
                     raise RuntimeError(f"Binary not found at {exe_path}. Please compile your program first.")
-                controller.write(f"-file-exec-and-symbols {exe_path}", timeout_sec=GDB_TIMEOUT)
+                gdb_path = f'/workspace/{binary_file}' if container_name else exe_path
+                controller.write(f"-file-exec-and-symbols {gdb_path}", timeout_sec=GDB_TIMEOUT)
             except Exception:
                 try:
                     controller.exit()
@@ -367,6 +376,7 @@ class SessionManager:
                 controller.exit()
             except Exception as e:
                 logger.warning("Error exiting GDB for session %s: %s", session_id, e)
+        stop_container(session_id)
 
     def execute(self, session_id, command):
         validate_command(command)

--- a/gdbui_server/tests/test_sandbox.py
+++ b/gdbui_server/tests/test_sandbox.py
@@ -1,0 +1,96 @@
+"""Tests for the sandbox module."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestSandboxDisabled(unittest.TestCase):
+    """When GDBUI_DOCKER is not set, start/stop are no-ops."""
+
+    def setUp(self):
+        # Ensure env var is not set
+        os.environ.pop("GDBUI_DOCKER", None)
+        # Force reimport with clean env
+        if "sandbox" in sys.modules:
+            del sys.modules["sandbox"]
+
+    def test_start_returns_none_when_disabled(self):
+        from sandbox import start_container
+
+        self.assertIsNone(start_container("any-sid", "/tmp"))
+
+    def test_stop_does_nothing_when_disabled(self):
+        from sandbox import stop_container
+
+        try:
+            stop_container("any-sid")
+        except Exception:
+            self.fail("stop_container raised unexpectedly")
+
+    def test_container_name_ignores_env(self):
+        from sandbox import _container_name
+
+        self.assertEqual(_container_name("a1b2c3d4"), "gdbui-a1b2c3d4")
+        self.assertEqual(_container_name("550e8400-e29b-41d4-a716"), "gdbui-550e8400")
+
+
+class TestSandboxEnabled(unittest.TestCase):
+    """When GDBUI_DOCKER=true, start/stop shell out to docker CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["GDBUI_DOCKER"] = "true"
+        if "sandbox" in sys.modules:
+            del sys.modules["sandbox"]
+        import sandbox as sb
+
+        cls.sb = sb
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("GDBUI_DOCKER", None)
+
+    @patch("sandbox.subprocess.run")
+    def test_start_runs_docker(self, mock_run):
+        name = self.sb.start_container("550e8400-e29b-41d4-a716", "output/sid")
+        self.assertEqual(name, "gdbui-550e8400")
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("docker", call_args)
+        self.assertIn("run", call_args)
+        self.assertIn("gdbui-550e8400", call_args)
+        self.assertIn("--read-only", call_args)
+        self.assertIn("--network", call_args)
+        self.assertIn("none", call_args)
+
+    @patch("sandbox.subprocess.run")
+    def test_start_mounts_output_dir(self, mock_run):
+        self.sb.start_container("sid12345", "output/sid12345")
+        call_args = mock_run.call_args[0][0]
+        vol_idx = call_args.index("-v") + 1
+        self.assertIn("output/sid12345:/workspace", call_args[vol_idx])
+
+    @patch("sandbox.subprocess.run")
+    def test_stop_runs_docker_rm(self, mock_run):
+        self.sb.stop_container("550e8400-e29b-41d4-a716")
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("docker", call_args)
+        self.assertIn("rm", call_args)
+
+    @patch("sandbox.subprocess.run")
+    def test_stop_silent_on_missing(self, mock_run):
+        mock_run.side_effect = Exception("container not found")
+        self.sb.stop_container("missing")
+
+    @patch("sandbox.subprocess.run")
+    def test_start_returns_none_on_failure(self, mock_run):
+        mock_run.side_effect = Exception("docker daemon not running")
+        result = self.sb.start_container("any", "/tmp")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gdbui_server/tests/test_session_manager.py
+++ b/gdbui_server/tests/test_session_manager.py
@@ -278,5 +278,101 @@ class TestSessionManager(unittest.TestCase):
         self.assertEqual(normalize_program_name('test'), 'test')
 
 
+class TestSessionManagerSandbox(unittest.TestCase):
+    """Sandbox-enabled behavior: GDB runs inside a per-session Docker container."""
+
+    def _make_mock_controller(self):
+        controller = MagicMock()
+        controller.write.return_value = [{'payload': 'mock output'}]
+        controller.exit.return_value = None
+        return controller
+
+    @patch('session_manager.SANDBOX_ENABLED', True)
+    @patch('session_manager.start_container', return_value='gdbui-abc12345')
+    @patch('session_manager.stop_container')
+    @patch('session_manager.os.path.exists', return_value=True)
+    @patch('session_manager.GdbController')
+    def test_start_gdb_uses_docker_exec(self, MockGdbController, mock_exists,
+                                        mock_stop, mock_start):
+        mock_controller = self._make_mock_controller()
+        MockGdbController.return_value = mock_controller
+
+        sm = SessionManager()
+        sid, _ = sm.create_session()
+        sm.start_gdb(sid, 'program')
+
+        mock_start.assert_called_once_with(sid, os.path.join('output', sid))
+        MockGdbController.assert_called_once_with(
+            command=['docker', 'exec', '-i', 'gdbui-abc12345', 'gdb', '--interpreter=mi2'])
+        mock_controller.write.assert_called_once_with(
+            '-file-exec-and-symbols /workspace/program.exe', timeout_sec=30)
+        sm.shutdown()
+
+    @patch('session_manager.SANDBOX_ENABLED', True)
+    @patch('session_manager.start_container', return_value='gdbui-abc12345')
+    @patch('session_manager.os.path.exists', return_value=True)
+    @patch('session_manager.GdbController')
+    def test_end_session_stops_container(self, MockGdbController, mock_exists, mock_start):
+        mock_controller = self._make_mock_controller()
+        MockGdbController.return_value = mock_controller
+
+        sm = SessionManager()
+        sid, _ = sm.create_session()
+        sm.start_gdb(sid, 'program')
+
+        with patch('session_manager.stop_container') as mock_stop:
+            sm.end_session(sid)
+            mock_stop.assert_called_once_with(sid)
+
+    @patch('session_manager.SANDBOX_ENABLED', True)
+    @patch('session_manager.start_container', return_value='gdbui-abc12345')
+    @patch('session_manager.os.path.exists', return_value=True)
+    @patch('session_manager.GdbController')
+    def test_stop_gdb_stops_container(self, MockGdbController, mock_exists, mock_start):
+        mock_controller = self._make_mock_controller()
+        MockGdbController.return_value = mock_controller
+
+        sm = SessionManager()
+        sid, _ = sm.create_session()
+        sm.start_gdb(sid, 'program')
+
+        with patch('session_manager.stop_container') as mock_stop:
+            sm.stop_gdb(sid)
+            mock_stop.assert_called_once_with(sid)
+
+    @patch('session_manager.SANDBOX_ENABLED', True)
+    @patch('session_manager.start_container', return_value=None)
+    @patch('session_manager.stop_container')
+    @patch('session_manager.os.path.exists', return_value=True)
+    @patch('session_manager.GdbController')
+    def test_start_gdb_fails_closed_when_container_unavailable(self, MockGdbController,
+                                                               mock_exists, mock_stop, mock_start):
+        sm = SessionManager()
+        sid, _ = sm.create_session()
+        with self.assertRaises(RuntimeError):
+            sm.start_gdb(sid, 'program')
+        MockGdbController.assert_not_called()
+        sm.shutdown()
+
+    @patch('session_manager.SANDBOX_ENABLED', True)
+    @patch('session_manager.start_container', return_value='gdbui-abc12345')
+    @patch('session_manager.stop_container')
+    @patch('session_manager.os.path.exists', return_value=True)
+    @patch('session_manager.GdbController')
+    def test_program_switch_stops_container_before_restart(self, MockGdbController,
+                                                           mock_exists, mock_stop, mock_start):
+        controllers = [self._make_mock_controller(), self._make_mock_controller()]
+        MockGdbController.side_effect = controllers
+
+        sm = SessionManager()
+        sid, _ = sm.create_session()
+        sm.start_gdb(sid, 'program_a')
+        sm.start_gdb(sid, 'program_b')
+
+        self.assertEqual(mock_stop.call_count, 1)
+        self.assertEqual(mock_start.call_count, 2)
+        sm.shutdown()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

PR 2 of Phase 3 (Docker sandbox isolation). Activates the sandbox built in #211 — when `GDBUI_DOCKER=true`, GDB runs inside a per-session Docker container instead of on the host.

## Changes

`gdbui_server/session_manager.py` (14 lines changed):
- **`start_gdb`**: calls `start_container()` before creating the controller. When a container is running, `GdbController` launches `docker exec -i <name> gdb --interpreter=mi2` and loads the binary at `/workspace/<name>.exe` (the output dir is bind-mounted). Fails closed if the container can't start.
- **Container teardown mirrors controller teardown** across every path:
  - `stop_gdb` — stops container
  - `end_session` — stops container before rmtree
  - `_end_session_if_expired` — stops container before rmtree (previously would leak a container for 24h)
  - `start_gdb` program-switch — stops old container before starting a new one (prevents `docker run --name` collision)

`gdbui_server/tests/test_session_manager.py`: +5 sandbox tests (docker exec wiring, teardown on stop/end/switch, fail-closed).

## Behavior

- **Disabled (default, `GDBUI_DOCKER=false`)**: zero behavioral change. All existing 49 tests pass unchanged.
- **Enabled**: per-session isolation — read-only rootfs, no network, tmpfs scratch.

## Test Plan

- [x] `python3 -m unittest discover -s tests` — 54 passing (49 existing + 5 new)
- [ ] Manual: `GDBUI_DOCKER=true docker compose up` → compile + debug runs isolated

## Notes

Stacked on #211 (branch created from `feat/docker-sandbox-infra`). After #211 merges, this PR's diff shrinks to the session-manager changes only.

Related: #211 (infrastructure), closes the Phase 3 PR-2 milestone.